### PR TITLE
chore: configure SonarCloud to analyze only /src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             /k:"CasteloBrancoLab_Bedrock" \
             /o:"castelobrancolab" \
             /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.sources="src" \
+            /d:sonar.tests="tests" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml"
 
       - name: Build


### PR DESCRIPTION
## Summary

- Configura SonarScanner para analisar apenas codigo em `/src`
- Define `/tests` como diretorio de testes para contexto

## Test plan

- [ ] Pipeline CI passa com sucesso
- [ ] SonarCloud analisa apenas arquivos em src/

Closes #12

Generated with [Claude Code](https://claude.com/claude-code)
