### PR TITLE
feat(core): migrate RegistryVersion from McioFramework

### DIFF
--- a/src/BuildingBlocks/Core/RegistryVersions/RegistryVersion.cs
+++ b/src/BuildingBlocks/Core/RegistryVersions/RegistryVersion.cs
@@ -1,0 +1,239 @@
+namespace Bedrock.BuildingBlocks.Core.RegistryVersions;
+
+/// <summary>
+/// Representa uma versão de registro monotônica baseada em timestamp.
+/// Ideal para controle de versão de entidades, optimistic locking e event sourcing.
+/// </summary>
+/// <remarks>
+/// CARACTERÍSTICAS:
+/// - Performance: ~40 nanosegundos por versão (mais rápido que Id/UUIDv7)
+/// - Tamanho: 8 bytes (50% menor que Guid/UUIDv7)
+/// - Ordenação: Naturalmente ordenável por timestamp
+/// - Thread-safe: Usa ThreadStatic, sem locks
+/// - Monotônico: Versões são sempre crescentes, mesmo se o relógio retroceder
+/// - Proteção contra clock drift: Mantém monotonicidade mesmo com ajustes de horário
+/// - Resolução: 100 nanosegundos (1 tick = 100ns)
+///
+/// ESTRUTURA DO LONG (64 bits / 8 bytes):
+/// ┌────────────────────────────────────────────────────────────┐
+/// │           UTC Ticks (64 bits)                              │
+/// │           ~29.000 anos desde 01/01/0001 00:00:00 UTC.      │
+/// │           Resolução: 100 nanosegundos                      │
+/// └────────────────────────────────────────────────────────────┘
+///
+/// CASOS DE USO IDEAIS:
+/// - Versões de entidades (optimistic locking)
+/// - Event sourcing (número de sequência de eventos)
+/// - Audit logs (versionamento de mudanças)
+/// - Qualquer cenário que precise de versões ordenadas temporalmente
+///
+/// QUANDO NÃO USAR:
+/// - Identificadores primários distribuídos → Use Id (UUIDv7) para unicidade global sem coordenação
+/// - APIs que esperam UUIDs → Use Id (UUIDv7) para compatibilidade
+/// - Múltiplas instâncias sem coordenação → Use Id (UUIDv7) com bytes aleatórios
+/// </remarks>
+public readonly struct RegistryVersion
+    : IEquatable<RegistryVersion>, IComparable<RegistryVersion>
+{
+    [ThreadStatic] private static long _lastTicks;
+
+    /// <summary>
+    /// Valor bruto da versão (UTC ticks).
+    /// Representa o número de intervalos de 100 nanosegundos desde 01/01/0001 00:00:00 UTC.
+    /// </summary>
+    public long Value { get; }
+
+    /// <summary>
+    /// Converte o valor da versão para DateTimeOffset.
+    /// </summary>
+    public DateTimeOffset AsDateTimeOffset => new(Value, TimeSpan.Zero);
+
+    private RegistryVersion(long value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gera uma nova versão monotônica baseada no timestamp atual.
+    /// </summary>
+    /// <returns>Nova versão ordenável e monotônica.</returns>
+    /// <remarks>
+    /// CARACTERÍSTICAS:
+    /// - Performance: ~40 nanosegundos por versão
+    /// - Ordenação: Versões são ordenáveis por timestamp
+    /// - Thread-safe: Cada thread mantém seu próprio último tick, sem necessidade de locks
+    /// - Monotônico: Versões de uma mesma thread são sempre crescentes, mesmo se o relógio retroceder
+    /// - Resolução: 100 nanosegundos (1 tick)
+    ///
+    /// PROTEÇÃO CONTRA CLOCK DRIFT:
+    /// Se o relógio do sistema retroceder, a versão será incrementada em 1 tick (100ns)
+    /// a partir do último valor válido, garantindo monotonicidade.
+    /// </remarks>
+    public static RegistryVersion GenerateNewVersion()
+    {
+        return GenerateNewVersion(TimeProvider.System.GetUtcNow());
+    }
+
+    /// <summary>
+    /// Gera uma nova versão monotônica com TimeProvider customizado (útil para testes com tempo fixo).
+    /// </summary>
+    /// <param name="timeProvider">Provider de tempo customizado.</param>
+    /// <returns>Nova versão ordenável e monotônica.</returns>
+    /// <remarks>
+    /// Este overload permite injeção de dependência de tempo, tornando a geração de versões
+    /// completamente testável. Use TimeProvider customizado para testes com tempo fixo.
+    ///
+    /// Exemplo:
+    ///   var fixedTime = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero);
+    ///   var timeProvider = new CustomTimeProvider(
+    ///       utcNowFunc: _ => fixedTime,
+    ///       localTimeZone: null
+    ///   );
+    ///   var v1 = RegistryVersion.GenerateNewVersion(timeProvider);
+    ///   var v2 = RegistryVersion.GenerateNewVersion(timeProvider);
+    ///   // v1 terá ticks do fixedTime
+    ///   // v2 terá ticks do fixedTime + 1 (proteção contra mesmo timestamp)
+    /// </remarks>
+    public static RegistryVersion GenerateNewVersion(TimeProvider timeProvider)
+    {
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        return GenerateNewVersion(now);
+    }
+
+    /// <summary>
+    /// Gera uma nova versão monotônica com um timestamp específico.
+    /// </summary>
+    /// <param name="dateTimeOffset">Timestamp a ser usado na versão.</param>
+    /// <returns>Nova versão ordenável e monotônica.</returns>
+    /// <remarks>
+    /// Este é o método core de geração. Todos os outros overloads delegam para este método.
+    ///
+    /// COMPORTAMENTO COM CLOCK DRIFT:
+    /// - Se o timestamp atual for maior que o último: usa o timestamp atual
+    /// - Se o timestamp atual for menor ou igual ao último: usa o último + 1 tick (100ns)
+    ///
+    /// Isso garante que versões sejam SEMPRE crescentes, mesmo se:
+    /// - O relógio do sistema retroceder (ajuste de horário, NTP, virtualização)
+    /// - Múltiplas versões forem geradas no mesmo instante
+    /// - Bugs de hardware ou sincronização
+    ///
+    /// Exemplo:
+    ///   var timestamp = DateTimeOffset.UtcNow;
+    ///   var v1 = RegistryVersion.GenerateNewVersion(timestamp);
+    ///   var v2 = RegistryVersion.GenerateNewVersion(timestamp); // mesmo timestamp!
+    ///   // v1.Value = timestamp.UtcTicks
+    ///   // v2.Value = timestamp.UtcTicks + 1 (proteção contra duplicata)
+    ///   // Garante que v2 > v1 SEMPRE
+    /// </remarks>
+    public static RegistryVersion GenerateNewVersion(DateTimeOffset dateTimeOffset)
+    {
+        long ticks = dateTimeOffset.UtcTicks;
+
+        // Proteção contra clock drift e duplicatas:
+        // Se o timestamp atual for menor ou igual ao último válido,
+        // incrementamos em 1 tick (100ns) para garantir monotonicidade.
+        //
+        // CENÁRIO 1: Tempo avançou normalmente (ticks > _lastTicks)
+        //   - Usa o timestamp atual
+        //
+        // CENÁRIO 2: Relógio retrocedeu ou tempo igual (ticks <= _lastTicks)
+        //   - Usa último valor + 1 tick
+        //   - Garante que versão seja sempre maior que a anterior
+        //   - Exemplos: ajuste NTP, múltiplas chamadas simultâneas, virtualização
+        if (ticks <= _lastTicks)
+            ticks = _lastTicks + 1;
+
+        _lastTicks = ticks;
+        return new RegistryVersion(ticks);
+    }
+
+    /// <summary>
+    /// Cria uma versão a partir de um valor long existente (UTC ticks).
+    /// </summary>
+    /// <param name="value">Valor bruto da versão (UTC ticks).</param>
+    /// <returns>Versão criada a partir do valor.</returns>
+    public static RegistryVersion CreateFromExistingInfo(long value)
+    {
+        return new RegistryVersion(value);
+    }
+
+    /// <summary>
+    /// Cria uma versão a partir de um DateTimeOffset.
+    /// </summary>
+    /// <param name="dateTimeOffset">Data/hora a ser convertida em versão.</param>
+    /// <returns>Versão criada a partir do DateTimeOffset.</returns>
+    /// <remarks>
+    /// ATENÇÃO: Este método NÃO aplica proteção contra clock drift.
+    /// Use apenas para reconstruir versões a partir de valores conhecidos/armazenados.
+    /// Para gerar novas versões, use GenerateNewVersion().
+    /// </remarks>
+    public static RegistryVersion CreateFromExistingInfo(DateTimeOffset dateTimeOffset)
+    {
+        return new RegistryVersion(dateTimeOffset.UtcTicks);
+    }
+
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is RegistryVersion other && Equals(other);
+    }
+
+    public bool Equals(RegistryVersion other)
+    {
+        return Value == other.Value;
+    }
+
+    public int CompareTo(RegistryVersion other)
+    {
+        return Value.CompareTo(other.Value);
+    }
+
+    public override string ToString()
+    {
+        return Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    public static implicit operator long(RegistryVersion version)
+    {
+        return version.Value;
+    }
+
+    public static implicit operator RegistryVersion(long value)
+    {
+        return CreateFromExistingInfo(value);
+    }
+
+    public static bool operator ==(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value == right.Value;
+    }
+
+    public static bool operator !=(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value != right.Value;
+    }
+
+    public static bool operator <(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value < right.Value;
+    }
+
+    public static bool operator >(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value > right.Value;
+    }
+
+    public static bool operator <=(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value <= right.Value;
+    }
+
+    public static bool operator >=(RegistryVersion left, RegistryVersion right)
+    {
+        return left.Value >= right.Value;
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Core/RegistryVersions/RegistryVersionTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/RegistryVersions/RegistryVersionTests.cs
@@ -1,0 +1,680 @@
+using Bedrock.BuildingBlocks.Core.RegistryVersions;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.RegistryVersions;
+
+public class RegistryVersionTests : TestBase
+{
+    public RegistryVersionTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void GenerateNewVersion_ShouldReturnValidVersion()
+    {
+        // Arrange
+        LogArrange("Preparing to generate a new RegistryVersion");
+
+        // Act
+        LogAct("Generating new RegistryVersion");
+        var version = RegistryVersion.GenerateNewVersion();
+
+        // Assert
+        LogAssert("Verifying version value is greater than zero");
+        version.Value.ShouldBeGreaterThan(0);
+        LogInfo("Generated version: {0}", version.Value);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_ShouldBeMonotonic()
+    {
+        // Arrange
+        LogArrange("Preparing to generate multiple versions in rapid succession");
+        const int count = 1000;
+        var versions = new RegistryVersion[count];
+
+        // Act
+        LogAct($"Generating {count} versions");
+        for (int i = 0; i < count; i++)
+        {
+            versions[i] = RegistryVersion.GenerateNewVersion();
+        }
+
+        // Assert
+        LogAssert("Verifying versions are monotonically increasing");
+        for (int i = 1; i < count; i++)
+        {
+            versions[i].ShouldBeGreaterThan(versions[i - 1],
+                $"Version at index {i} should be greater than version at index {i - 1}");
+        }
+        LogInfo("All {0} versions are monotonically increasing", count);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_WithTimeProvider_ShouldUseProvidedTime()
+    {
+        // Arrange
+        LogArrange("Creating a fixed time provider");
+        var fixedTime = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var timeProvider = new FixedTimeProvider(fixedTime);
+
+        // Act
+        LogAct("Generating version with fixed time provider");
+        var version = RegistryVersion.GenerateNewVersion(timeProvider);
+
+        // Assert
+        LogAssert("Verifying version value corresponds to fixed time ticks");
+        version.Value.ShouldBeGreaterThanOrEqualTo(fixedTime.UtcTicks);
+        LogInfo("Generated version with fixed time: {0}", version.Value);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_WithDateTimeOffset_ShouldUseProvidedTime()
+    {
+        // Arrange
+        LogArrange("Creating a fixed DateTimeOffset");
+        var fixedTime = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Generating version with DateTimeOffset");
+        var version = RegistryVersion.GenerateNewVersion(fixedTime);
+
+        // Assert
+        LogAssert("Verifying version value corresponds to provided ticks");
+        version.Value.ShouldBeGreaterThanOrEqualTo(fixedTime.UtcTicks);
+        LogInfo("Generated version: {0}", version.Value);
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_WithLong_ShouldPreserveValue()
+    {
+        // Arrange
+        LogArrange("Creating a known long value");
+        long expectedValue = 638500000000000000L;
+
+        // Act
+        LogAct("Creating version from existing long");
+        var version = RegistryVersion.CreateFromExistingInfo(expectedValue);
+
+        // Assert
+        LogAssert("Verifying long value is preserved");
+        version.Value.ShouldBe(expectedValue);
+        LogInfo("Version value matches original long");
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_WithDateTimeOffset_ShouldConvertToTicks()
+    {
+        // Arrange
+        LogArrange("Creating a DateTimeOffset");
+        var dateTime = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Creating version from DateTimeOffset");
+        var version = RegistryVersion.CreateFromExistingInfo(dateTime);
+
+        // Assert
+        LogAssert("Verifying value equals UTC ticks");
+        version.Value.ShouldBe(dateTime.UtcTicks);
+        LogInfo("Version created from DateTimeOffset");
+    }
+
+    [Fact]
+    public void AsDateTimeOffset_ShouldReturnCorrectDateTime()
+    {
+        // Arrange
+        LogArrange("Creating a version from known DateTime");
+        var expectedDateTime = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var version = RegistryVersion.CreateFromExistingInfo(expectedDateTime);
+
+        // Act
+        LogAct("Getting AsDateTimeOffset");
+        var actualDateTime = version.AsDateTimeOffset;
+
+        // Assert
+        LogAssert("Verifying DateTimeOffset conversion");
+        actualDateTime.ShouldBe(expectedDateTime);
+        LogInfo("AsDateTimeOffset: {0}", actualDateTime);
+    }
+
+    [Fact]
+    public void ImplicitConversion_ToLong_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Generating a new version");
+        var version = RegistryVersion.GenerateNewVersion();
+
+        // Act
+        LogAct("Implicitly converting version to long");
+        long longValue = version;
+
+        // Assert
+        LogAssert("Verifying conversion preserves value");
+        longValue.ShouldBe(version.Value);
+        LogInfo("Implicit conversion to long successful");
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromLong_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating a long value");
+        long longValue = 638500000000000000L;
+
+        // Act
+        LogAct("Implicitly converting long to version");
+        RegistryVersion version = longValue;
+
+        // Assert
+        LogAssert("Verifying conversion preserves value");
+        version.Value.ShouldBe(longValue);
+        LogInfo("Implicit conversion from long successful");
+    }
+
+    [Fact]
+    public void Equals_WithSameValue_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two versions with same value");
+        long value = 638500000000000000L;
+        var version1 = RegistryVersion.CreateFromExistingInfo(value);
+        var version2 = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act
+        LogAct("Comparing versions for equality");
+        var areEqual = version1.Equals(version2);
+
+        // Assert
+        LogAssert("Verifying versions are equal");
+        areEqual.ShouldBeTrue();
+        LogInfo("Versions with same value are equal");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValue_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating two different versions");
+        var version1 = RegistryVersion.GenerateNewVersion();
+        var version2 = RegistryVersion.GenerateNewVersion();
+
+        // Act
+        LogAct("Comparing versions for equality");
+        var areEqual = version1.Equals(version2);
+
+        // Assert
+        LogAssert("Verifying versions are not equal");
+        areEqual.ShouldBeFalse();
+        LogInfo("Different versions are not equal");
+    }
+
+    [Fact]
+    public void Equals_WithObjectParameter_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating version and object for equality test");
+        long value = 638500000000000000L;
+        var version = RegistryVersion.CreateFromExistingInfo(value);
+        object objSame = RegistryVersion.CreateFromExistingInfo(value);
+        object objDifferent = RegistryVersion.CreateFromExistingInfo(value + 1);
+        object? objNull = null;
+        object objWrongType = "not a version";
+
+        // Act & Assert
+        LogAct("Testing Equals with various object types");
+        version.Equals(objSame).ShouldBeTrue("Equal version objects should be equal");
+        version.Equals(objDifferent).ShouldBeFalse("Different version objects should not be equal");
+        version.Equals(objNull).ShouldBeFalse("Null should not be equal");
+        version.Equals(objWrongType).ShouldBeFalse("Wrong type should not be equal");
+
+        LogAssert("Object equality tests passed");
+    }
+
+    [Fact]
+    public void EqualityOperator_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating two versions with same value");
+        long value = 638500000000000000L;
+        var version1 = RegistryVersion.CreateFromExistingInfo(value);
+        var version2 = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act & Assert
+        LogAct("Testing equality operator");
+        (version1 == version2).ShouldBeTrue();
+        LogAssert("Equality operator works correctly");
+    }
+
+    [Fact]
+    public void InequalityOperator_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating two different versions");
+        var version1 = RegistryVersion.GenerateNewVersion();
+        var version2 = RegistryVersion.GenerateNewVersion();
+
+        // Act & Assert
+        LogAct("Testing inequality operator");
+        (version1 != version2).ShouldBeTrue();
+        LogAssert("Inequality operator works correctly");
+    }
+
+    [Fact]
+    public void ComparisonOperators_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating two sequential versions");
+        var version1 = RegistryVersion.GenerateNewVersion();
+        var version2 = RegistryVersion.GenerateNewVersion();
+
+        // Act & Assert
+        LogAct("Testing comparison operators");
+        (version1 < version2).ShouldBeTrue("First version should be less than second");
+        (version2 > version1).ShouldBeTrue("Second version should be greater than first");
+        (version1 <= version2).ShouldBeTrue("First version should be less than or equal to second");
+        (version2 >= version1).ShouldBeTrue("Second version should be greater than or equal to first");
+#pragma warning disable CS1718 // Comparison to same variable - intentional test of reflexive comparison operators
+        (version1 <= version1).ShouldBeTrue("Version should be less than or equal to itself");
+        (version1 >= version1).ShouldBeTrue("Version should be greater than or equal to itself");
+#pragma warning restore CS1718
+        LogAssert("All comparison operators work correctly");
+    }
+
+    [Fact]
+    public void ComparisonOperators_LessThan_WithEqualVersions_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating two versions with same value");
+        long value = 638500000000000000L;
+        var version1 = RegistryVersion.CreateFromExistingInfo(value);
+        var version2 = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act & Assert
+        LogAct("Testing less than operator with equal values");
+        (version1 < version2).ShouldBeFalse("Equal versions should not be less than each other");
+        (version2 < version1).ShouldBeFalse("Equal versions should not be less than each other");
+        LogAssert("Less than operator returns false for equal versions");
+    }
+
+    [Fact]
+    public void ComparisonOperators_GreaterThan_WithEqualVersions_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating two versions with same value");
+        long value = 638500000000000000L;
+        var version1 = RegistryVersion.CreateFromExistingInfo(value);
+        var version2 = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act & Assert
+        LogAct("Testing greater than operator with equal values");
+        (version1 > version2).ShouldBeFalse("Equal versions should not be greater than each other");
+        (version2 > version1).ShouldBeFalse("Equal versions should not be greater than each other");
+        LogAssert("Greater than operator returns false for equal versions");
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldBeConsistent()
+    {
+        // Arrange
+        LogArrange("Creating a version");
+        long value = 638500000000000000L;
+        var version = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act
+        LogAct("Getting hash code multiple times");
+        var hash1 = version.GetHashCode();
+        var hash2 = version.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are consistent");
+        hash1.ShouldBe(hash2);
+        hash1.ShouldBe(value.GetHashCode());
+        LogInfo("Hash code is consistent: {0}", hash1);
+    }
+
+    [Fact]
+    public void CompareTo_ShouldReturnCorrectOrder()
+    {
+        // Arrange
+        LogArrange("Creating versions for comparison");
+        var smaller = RegistryVersion.CreateFromExistingInfo(100);
+        var larger = RegistryVersion.CreateFromExistingInfo(200);
+        var equal = RegistryVersion.CreateFromExistingInfo(100);
+
+        // Act & Assert
+        LogAct("Testing CompareTo method");
+        smaller.CompareTo(larger).ShouldBeLessThan(0);
+        larger.CompareTo(smaller).ShouldBeGreaterThan(0);
+        smaller.CompareTo(equal).ShouldBe(0);
+        LogAssert("CompareTo returns correct ordering");
+    }
+
+    [Fact]
+    public void ToString_ShouldReturnInvariantString()
+    {
+        // Arrange
+        LogArrange("Creating a version");
+        long value = 638500000000000000L;
+        var version = RegistryVersion.CreateFromExistingInfo(value);
+
+        // Act
+        LogAct("Converting to string");
+        var str = version.ToString();
+
+        // Assert
+        LogAssert("Verifying string representation");
+        str.ShouldBe("638500000000000000");
+        LogInfo("ToString result: {0}", str);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_WithClockDrift_ShouldMaintainMonotonicity()
+    {
+        // Arrange
+        LogArrange("Creating timestamps simulating clock drift");
+        var futureTime = DateTimeOffset.UtcNow.AddSeconds(10);
+        var pastTime = DateTimeOffset.UtcNow.AddSeconds(-10);
+
+        // Act
+        LogAct("Generating version with future time, then past time");
+        var versionFuture = RegistryVersion.GenerateNewVersion(futureTime);
+        var versionPast = RegistryVersion.GenerateNewVersion(pastTime);
+
+        // Assert
+        LogAssert("Verifying past version is still greater (monotonic guarantee)");
+        versionPast.ShouldBeGreaterThan(versionFuture,
+            "Clock drift should be handled - later generated version should be greater");
+        LogInfo("Clock drift handled correctly");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_WithSameTimestamp_ShouldIncrement()
+    {
+        // Arrange
+        LogArrange("Creating fixed timestamp");
+        var fixedTime = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Generating multiple versions with same timestamp");
+        var v1 = RegistryVersion.GenerateNewVersion(fixedTime);
+        var v2 = RegistryVersion.GenerateNewVersion(fixedTime);
+        var v3 = RegistryVersion.GenerateNewVersion(fixedTime);
+
+        // Assert
+        LogAssert("Verifying versions are different and ordered");
+        v1.Value.ShouldNotBe(v2.Value);
+        v2.Value.ShouldNotBe(v3.Value);
+        v2.ShouldBeGreaterThan(v1);
+        v3.ShouldBeGreaterThan(v2);
+        LogInfo("Same timestamp increment working correctly");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_SameTimestamp_IncrementsByOneTick()
+    {
+        // Arrange
+        LogArrange("Creating fixed timestamp for increment verification");
+        var fixedTime = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Generating versions with same timestamp");
+        var v1 = RegistryVersion.GenerateNewVersion(fixedTime);
+        var v2 = RegistryVersion.GenerateNewVersion(fixedTime);
+        var v3 = RegistryVersion.GenerateNewVersion(fixedTime);
+
+        // Assert
+        LogAssert("Verifying increment is exactly 1 tick");
+        (v2.Value - v1.Value).ShouldBe(1, "Increment should be exactly 1 tick (100ns)");
+        (v3.Value - v2.Value).ShouldBe(1, "Increment should be exactly 1 tick (100ns)");
+        LogInfo("Versions: {0} -> {1} -> {2}", v1.Value, v2.Value, v3.Value);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_NewerTimestamp_UsesNewTimestamp()
+    {
+        // Arrange - usar timestamps bem no futuro para evitar interferencia de outros testes
+        LogArrange("Creating two timestamps far in the future");
+        var time1 = new DateTimeOffset(2200, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var time2 = new DateTimeOffset(2200, 1, 1, 0, 0, 1, TimeSpan.Zero); // 1 second later
+
+        // Act
+        LogAct("Generating versions with different timestamps");
+        var v1 = RegistryVersion.GenerateNewVersion(time1);
+        var v2 = RegistryVersion.GenerateNewVersion(time2);
+
+        // Assert
+        LogAssert("Verifying newer timestamp produces greater version");
+        v2.ShouldBeGreaterThan(v1);
+        // Como time2 > time1 > _lastTicks (do time1), o time2 sera usado diretamente
+        v2.Value.ShouldBe(time2.UtcTicks, "Version should use newer timestamp directly");
+        LogInfo("Newer timestamp used correctly");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_ClockDriftBackwards_UsesLastTicksPlusOne()
+    {
+        // Arrange
+        LogArrange("Simulating clock drift backwards");
+        var normalTime = new DateTimeOffset(2032, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var driftedTime = new DateTimeOffset(2032, 6, 15, 11, 59, 59, TimeSpan.Zero);
+
+        // Act
+        LogAct("Generating version at normal time, then at drifted (earlier) time");
+        var vNormal = RegistryVersion.GenerateNewVersion(normalTime);
+        var vDrifted = RegistryVersion.GenerateNewVersion(driftedTime);
+
+        // Assert
+        LogAssert("Verifying monotonicity maintained despite clock drift");
+        vDrifted.ShouldBeGreaterThan(vNormal, "Later generated version should be greater even with clock drift");
+        (vDrifted.Value - vNormal.Value).ShouldBe(1, "Should increment by exactly 1 tick during drift");
+        LogInfo("Clock drift handled correctly - monotonicity maintained");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_MultipleRapidCalls_AllShouldBeUnique()
+    {
+        // Arrange
+        LogArrange("Preparing to generate many versions rapidly");
+        var fixedTime = new DateTimeOffset(2033, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        const int count = 100;
+        var versions = new HashSet<long>();
+
+        // Act
+        LogAct($"Generating {count} versions with same timestamp");
+        for (int i = 0; i < count; i++)
+        {
+            var version = RegistryVersion.GenerateNewVersion(fixedTime);
+            versions.Add(version.Value);
+        }
+
+        // Assert
+        LogAssert("Verifying all versions are unique");
+        versions.Count.ShouldBe(count, "All versions should be unique even with same timestamp");
+        LogInfo("All {0} versions are unique", count);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_ThreadSafety_EachThreadIsMonotonic()
+    {
+        // Arrange
+        // NOTA: RegistryVersion usa ThreadStatic, entao cada thread tem seu proprio _lastTicks.
+        // Isso significa que versoes DENTRO de uma thread sao monotonicas, mas podem haver
+        // duplicatas ENTRE threads se gerarem no mesmo tick. Este e o design esperado.
+        LogArrange("Preparing parallel version generation");
+        const int threadsCount = 10;
+        const int versionsPerThread = 100;
+        var threadResults = new System.Collections.Concurrent.ConcurrentDictionary<int, List<RegistryVersion>>();
+
+        // Act
+        LogAct($"Generating {versionsPerThread} versions in each of {threadsCount} threads");
+        Parallel.For(0, threadsCount, threadIndex =>
+        {
+            var versions = new List<RegistryVersion>();
+            for (int i = 0; i < versionsPerThread; i++)
+            {
+                versions.Add(RegistryVersion.GenerateNewVersion());
+            }
+            threadResults[threadIndex] = versions;
+        });
+
+        // Assert - cada thread deve ter versoes monotonicas
+        LogAssert("Verifying each thread has monotonically increasing versions");
+        foreach (var kvp in threadResults)
+        {
+            var versions = kvp.Value;
+            for (int i = 1; i < versions.Count; i++)
+            {
+                versions[i].ShouldBeGreaterThan(versions[i - 1],
+                    $"Thread {kvp.Key}: Version at index {i} should be greater than version at index {i - 1}");
+            }
+        }
+        LogInfo("All {0} threads have monotonically increasing versions", threadsCount);
+    }
+
+    [Fact]
+    public void GenerateNewVersion_StrictLessThanCheck()
+    {
+        // Mata mutante: ticks <= _lastTicks -> ticks < _lastTicks
+        // Se mutar, mesmo timestamp nao entraria no branch de incremento
+
+        // Arrange
+        LogArrange("Verificando que <= e usado corretamente");
+        var time = new DateTimeOffset(2040, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act - gera dois no MESMO timestamp
+        LogAct("Gerando 2 versoes com timestamp identico");
+        var v1 = RegistryVersion.GenerateNewVersion(time);
+        var v2 = RegistryVersion.GenerateNewVersion(time);
+
+        // Assert
+        LogAssert("Verificando que mesmo timestamp gera versoes diferentes");
+        v1.Value.ShouldNotBe(v2.Value);
+        v2.ShouldBeGreaterThan(v1);
+        (v2.Value - v1.Value).ShouldBe(1, "Diferenca deve ser exatamente 1 tick");
+        LogInfo("Check <= verificado corretamente");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_IncrementMustBePositive()
+    {
+        // Mata mutante: _lastTicks + 1 -> _lastTicks - 1
+
+        // Arrange
+        LogArrange("Verificando que incremento e +1, nao -1");
+        var time = new DateTimeOffset(2041, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Gerando 10 versoes sequenciais");
+        var versions = new List<RegistryVersion>();
+        for (int i = 0; i < 10; i++)
+        {
+            versions.Add(RegistryVersion.GenerateNewVersion(time));
+        }
+
+        // Assert
+        LogAssert("Verificando unicidade e ordem crescente");
+        var uniqueValues = versions.Select(v => v.Value).Distinct().Count();
+        uniqueValues.ShouldBe(10, "Todas versoes devem ser unicas");
+
+        for (int i = 1; i < versions.Count; i++)
+        {
+            versions[i].ShouldBeGreaterThan(versions[i - 1], $"Versao {i} deve ser maior que versao {i - 1}");
+            (versions[i].Value - versions[i - 1].Value).ShouldBe(1, "Diferenca deve ser +1, nao -1");
+        }
+
+        LogInfo("Incremento positivo verificado");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_AssignmentToLastTicks()
+    {
+        // Mata mutante: _lastTicks = ticks -> statement removal
+
+        // Arrange - usar timestamps bem no futuro para evitar interferencia
+        LogArrange("Verificando que _lastTicks e atualizado");
+        var time1 = new DateTimeOffset(2300, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var time2 = new DateTimeOffset(2300, 1, 1, 0, 0, 0, 100, TimeSpan.Zero); // 100 ticks depois
+
+        // Act
+        LogAct("Gerando versoes e verificando persistencia de estado");
+        var v1 = RegistryVersion.GenerateNewVersion(time1);
+        var v2 = RegistryVersion.GenerateNewVersion(time1); // mesmo timestamp, deve usar _lastTicks
+        var v3 = RegistryVersion.GenerateNewVersion(time2); // timestamp maior
+
+        // Assert
+        LogAssert("Verificando que estado e mantido entre chamadas");
+        v2.Value.ShouldBe(v1.Value + 1, "Segundo deve incrementar do primeiro");
+        v3.Value.ShouldBe(time2.UtcTicks, "Terceiro deve usar timestamp maior");
+        v3.ShouldBeGreaterThan(v2, "Terceiro deve ser maior que segundo");
+
+        LogInfo("Atribuicao a _lastTicks verificada");
+    }
+
+    [Fact]
+    public void GenerateNewVersion_IfConditionPath()
+    {
+        // Mata mutante: if block removal
+
+        // Arrange - usar timestamps bem no futuro para evitar interferencia
+        LogArrange("Verificando ambos os caminhos do if");
+
+        // Act - caminho onde ticks > _lastTicks (tempo avanca)
+        LogAct("Testando caminho: tempo avanca");
+        var time1 = new DateTimeOffset(2400, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var time2 = new DateTimeOffset(2400, 1, 1, 0, 0, 1, TimeSpan.Zero);
+        var v1 = RegistryVersion.GenerateNewVersion(time1);
+        var v2 = RegistryVersion.GenerateNewVersion(time2);
+
+        // Assert - tempo avanca normalmente
+        LogAssert("Verificando que timestamp maior e usado diretamente");
+        v2.Value.ShouldBe(time2.UtcTicks);
+
+        // Act - caminho onde ticks <= _lastTicks (clock drift)
+        LogAct("Testando caminho: clock drift");
+        var v3 = RegistryVersion.GenerateNewVersion(time1); // tempo retrocede
+
+        // Assert - deve incrementar do ultimo
+        LogAssert("Verificando incremento em clock drift");
+        v3.ShouldBeGreaterThan(v2);
+        v3.Value.ShouldBe(v2.Value + 1);
+
+        LogInfo("Ambos caminhos do if verificados");
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_DateTimeOffset_DoesNotAffectLastTicks()
+    {
+        // Arrange
+        LogArrange("Verificando que CreateFromExistingInfo nao afeta _lastTicks");
+        var genTime = new DateTimeOffset(2044, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var existingTime = new DateTimeOffset(2050, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act
+        LogAct("Gerando versao, criando de existente, gerando novamente");
+        var v1 = RegistryVersion.GenerateNewVersion(genTime);
+        var vExisting = RegistryVersion.CreateFromExistingInfo(existingTime);
+        var v2 = RegistryVersion.GenerateNewVersion(genTime);
+
+        // Assert
+        LogAssert("Verificando que CreateFromExistingInfo nao afeta geracao");
+        vExisting.Value.ShouldBe(existingTime.UtcTicks);
+        v2.Value.ShouldBe(v1.Value + 1, "v2 deve ser v1 + 1, nao baseado em vExisting");
+
+        LogInfo("CreateFromExistingInfo nao afeta estado de geracao");
+    }
+
+    private class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _fixedTime;
+
+        public FixedTimeProvider(DateTimeOffset fixedTime)
+        {
+            _fixedTime = fixedTime;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _fixedTime;
+    }
+}


### PR DESCRIPTION
## Summary
- Migrate `RegistryVersion` value object from legacy McioFramework to Bedrock namespace
- Add comprehensive unit tests with 100% coverage and mutation score
- RegistryVersion provides monotonic timestamp-based versioning for optimistic locking and event sourcing

## Test plan
- [x] Run `./scripts/pipeline.sh` locally
- [x] Verify 100% code coverage
- [x] Verify 100% mutation score (197 mutants killed)
- [ ] CI pipeline passes

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)