### PR TITLE
feat(core): add pagination, sorting and filtering structures

### DIFF
--- a/src/BuildingBlocks/Core/Filterings/Enums/FilterOperator.cs
+++ b/src/BuildingBlocks/Core/Filterings/Enums/FilterOperator.cs
@@ -1,0 +1,103 @@
+namespace Bedrock.BuildingBlocks.Core.Filterings.Enums;
+
+/// <summary>
+/// Operadores de filtro suportados.
+/// </summary>
+/// <remarks>
+/// CATEGORIAS DE OPERADORES:
+///
+/// IGUALDADE:
+/// - Equals: Valor exato
+/// - NotEquals: Diferente de
+///
+/// TEXTO (strings):
+/// - Contains: Contém substring
+/// - StartsWith: Começa com
+/// - EndsWith: Termina com
+///
+/// COMPARAÇÃO (números, datas):
+/// - GreaterThan: Maior que
+/// - GreaterThanOrEquals: Maior ou igual
+/// - LessThan: Menor que
+/// - LessThanOrEquals: Menor ou igual
+///
+/// INTERVALO:
+/// - Between: Entre dois valores (requer Value e ValueEnd)
+///
+/// LISTA:
+/// - In: Está na lista (requer Values array)
+/// - NotIn: Não está na lista (requer Values array)
+/// </remarks>
+public enum FilterOperator
+{
+    /// <summary>
+    /// Valor exato (=).
+    /// </summary>
+    Equals = 1,
+
+    /// <summary>
+    /// Diferente de (!=).
+    /// </summary>
+    NotEquals = 2,
+
+    /// <summary>
+    /// Contém substring (LIKE '%value%').
+    /// Aplicável apenas a strings.
+    /// </summary>
+    Contains = 3,
+
+    /// <summary>
+    /// Começa com (LIKE 'value%').
+    /// Aplicável apenas a strings.
+    /// </summary>
+    StartsWith = 4,
+
+    /// <summary>
+    /// Termina com (LIKE '%value').
+    /// Aplicável apenas a strings.
+    /// </summary>
+    EndsWith = 5,
+
+    /// <summary>
+    /// Maior que (>).
+    /// Aplicável a números e datas.
+    /// </summary>
+    GreaterThan = 6,
+
+    /// <summary>
+    /// Maior ou igual (>=).
+    /// Aplicável a números e datas.
+    /// </summary>
+    GreaterThanOrEquals = 7,
+
+    /// <summary>
+    /// Menor que (&lt;).
+    /// Aplicável a números e datas.
+    /// </summary>
+    LessThan = 8,
+
+    /// <summary>
+    /// Menor ou igual (&lt;=).
+    /// Aplicável a números e datas.
+    /// </summary>
+    LessThanOrEquals = 9,
+
+    /// <summary>
+    /// Entre dois valores (BETWEEN).
+    /// Requer Value (início) e ValueEnd (fim).
+    /// Aplicável a números e datas.
+    /// </summary>
+    Between = 10,
+
+    /// <summary>
+    /// Está na lista (IN).
+    /// Requer Values array.
+    /// </summary>
+    In = 11,
+
+    /// <summary>
+    /// Não está na lista (NOT IN).
+    /// Requer Values array.
+    /// </summary>
+    NotIn = 12
+}

--- a/src/BuildingBlocks/Core/Filterings/FilterInfo.cs
+++ b/src/BuildingBlocks/Core/Filterings/FilterInfo.cs
@@ -1,0 +1,198 @@
+using Bedrock.BuildingBlocks.Core.Filterings.Enums;
+
+namespace Bedrock.BuildingBlocks.Core.Filterings;
+
+/// <summary>
+/// Representa informações de filtro para uma consulta.
+/// </summary>
+/// <remarks>
+/// CARACTERÍSTICAS:
+/// - Imutável: readonly struct para performance e segurança
+/// - Validado: Field não pode ser nulo ou vazio
+/// - Flexível: Suporta valor único, intervalo (Between) e lista (In/NotIn)
+///
+/// EXEMPLO DE USO (valor único):
+///   var filter = FilterInfo.Create("LastName", FilterOperator.Contains, "Silva");
+///
+/// EXEMPLO DE USO (intervalo - Between):
+///   var filter = FilterInfo.CreateBetween("CreatedAt", "2024-01-01", "2024-12-31");
+///
+/// EXEMPLO DE USO (lista - In):
+///   var filter = FilterInfo.CreateIn("Status", new[] { "Active", "Pending" });
+///
+/// SEGURANÇA:
+/// - O valor de Field deve ser validado contra uma whitelist (enum) na camada Infra.Data
+/// - Este struct apenas transporta a informação, não valida se o campo é permitido
+/// </remarks>
+public readonly struct FilterInfo : IEquatable<FilterInfo>
+{
+    /// <summary>
+    /// Nome do campo para filtro.
+    /// </summary>
+    /// <remarks>
+    /// Este valor deve ser validado contra uma whitelist de campos permitidos
+    /// na camada Infra.Data antes de ser usado em queries.
+    /// </remarks>
+    public string Field { get; }
+
+    /// <summary>
+    /// Operador de filtro (Equals, Contains, GreaterThan, etc.).
+    /// </summary>
+    public FilterOperator Operator { get; }
+
+    /// <summary>
+    /// Valor do filtro (para operadores de valor único).
+    /// </summary>
+    /// <remarks>
+    /// Usado para: Equals, NotEquals, Contains, StartsWith, EndsWith,
+    /// GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals.
+    /// Para Between, este é o valor inicial do intervalo.
+    /// </remarks>
+    public string? Value { get; }
+
+    /// <summary>
+    /// Valor final do intervalo (apenas para operador Between).
+    /// </summary>
+    public string? ValueEnd { get; }
+
+    /// <summary>
+    /// Lista de valores (apenas para operadores In e NotIn).
+    /// </summary>
+    public IReadOnlyList<string>? Values { get; }
+
+    private FilterInfo(
+        string field,
+        FilterOperator filterOperator,
+        string? value,
+        string? valueEnd,
+        IReadOnlyList<string>? values)
+    {
+        Field = field;
+        Operator = filterOperator;
+        Value = value;
+        ValueEnd = valueEnd;
+        Values = values;
+    }
+
+    /// <summary>
+    /// Cria um filtro com valor único.
+    /// </summary>
+    /// <param name="field">Nome do campo para filtro.</param>
+    /// <param name="filterOperator">Operador de filtro.</param>
+    /// <param name="value">Valor do filtro.</param>
+    /// <returns>Nova instância de FilterInfo.</returns>
+    /// <exception cref="ArgumentException">
+    /// Lançada quando field é nulo ou vazio.
+    /// </exception>
+    public static FilterInfo Create(string field, FilterOperator filterOperator, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field, nameof(field));
+
+        return new FilterInfo(field, filterOperator, value, null, null);
+    }
+
+    /// <summary>
+    /// Cria um filtro de intervalo (Between).
+    /// </summary>
+    /// <param name="field">Nome do campo para filtro.</param>
+    /// <param name="valueStart">Valor inicial do intervalo.</param>
+    /// <param name="valueEnd">Valor final do intervalo.</param>
+    /// <returns>Nova instância de FilterInfo com operador Between.</returns>
+    /// <exception cref="ArgumentException">
+    /// Lançada quando field é nulo ou vazio.
+    /// </exception>
+    public static FilterInfo CreateBetween(string field, string? valueStart, string? valueEnd)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field, nameof(field));
+
+        return new FilterInfo(field, FilterOperator.Between, valueStart, valueEnd, null);
+    }
+
+    /// <summary>
+    /// Cria um filtro de lista (In).
+    /// </summary>
+    /// <param name="field">Nome do campo para filtro.</param>
+    /// <param name="values">Lista de valores.</param>
+    /// <returns>Nova instância de FilterInfo com operador In.</returns>
+    /// <exception cref="ArgumentException">
+    /// Lançada quando field é nulo ou vazio.
+    /// </exception>
+    public static FilterInfo CreateIn(string field, IReadOnlyList<string> values)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field, nameof(field));
+
+        return new FilterInfo(field, FilterOperator.In, null, null, values);
+    }
+
+    /// <summary>
+    /// Cria um filtro de lista negativa (NotIn).
+    /// </summary>
+    /// <param name="field">Nome do campo para filtro.</param>
+    /// <param name="values">Lista de valores a excluir.</param>
+    /// <returns>Nova instância de FilterInfo com operador NotIn.</returns>
+    /// <exception cref="ArgumentException">
+    /// Lançada quando field é nulo ou vazio.
+    /// </exception>
+    public static FilterInfo CreateNotIn(string field, IReadOnlyList<string> values)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field, nameof(field));
+
+        return new FilterInfo(field, FilterOperator.NotIn, null, null, values);
+    }
+
+    /// <summary>
+    /// Cria uma instância de FilterInfo a partir de valores existentes sem validação.
+    /// </summary>
+    /// <remarks>
+    /// ATENÇÃO: Este método NÃO valida os parâmetros.
+    /// Use apenas para reconstruir FilterInfo a partir de valores conhecidos/armazenados.
+    /// Para criar novas instâncias, use Create(), CreateBetween(), CreateIn() ou CreateNotIn().
+    /// </remarks>
+    public static FilterInfo CreateFromExistingInfo(
+        string field,
+        FilterOperator filterOperator,
+        string? value,
+        string? valueEnd,
+        IReadOnlyList<string>? values)
+    {
+        return new FilterInfo(field, filterOperator, value, valueEnd, values);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Field, Operator, Value, ValueEnd);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is FilterInfo other && Equals(other);
+    }
+
+    public bool Equals(FilterInfo other)
+    {
+        return Field == other.Field
+            && Operator == other.Operator
+            && Value == other.Value
+            && ValueEnd == other.ValueEnd;
+    }
+
+    public override string ToString()
+    {
+        return Operator switch
+        {
+            FilterOperator.Between => $"{Field} {Operator} [{Value}, {ValueEnd}]",
+            FilterOperator.In or FilterOperator.NotIn => $"{Field} {Operator} [{string.Join(", ", Values ?? [])}]",
+            _ => $"{Field} {Operator} {Value}"
+        };
+    }
+
+    public static bool operator ==(FilterInfo left, FilterInfo right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(FilterInfo left, FilterInfo right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/src/BuildingBlocks/Core/Paginations/PaginationInfo.cs
+++ b/src/BuildingBlocks/Core/Paginations/PaginationInfo.cs
@@ -1,0 +1,310 @@
+using Bedrock.BuildingBlocks.Core.Filterings;
+using Bedrock.BuildingBlocks.Core.Sortings;
+
+namespace Bedrock.BuildingBlocks.Core.Paginations;
+
+/// <summary>
+/// Representa informações de paginação para consultas, incluindo ordenação e filtros opcionais.
+/// </summary>
+/// <remarks>
+/// CARACTERÍSTICAS:
+/// - Imutável: readonly struct para performance e segurança
+/// - Validado: Página e tamanho devem ser maiores que zero
+/// - Calculado: Index e Offset são derivados automaticamente
+/// - Flexível: Ordenação e filtros são opcionais
+///
+/// PROPRIEDADES OBRIGATÓRIAS:
+/// - Page: Número da página (1-indexed, mínimo 1)
+/// - PageSize: Quantidade de itens por página (mínimo 1)
+/// - Index: Índice base-zero da página (Page - 1)
+/// - Offset: Quantidade de itens a pular (Index * PageSize)
+///
+/// PROPRIEDADES OPCIONAIS:
+/// - SortCollection: Lista de ordenações (pode ser vazia ou null)
+/// - FilterCollection: Lista de filtros (pode ser vazia ou null)
+///
+/// EXEMPLO DE USO (apenas paginação):
+///   var pagination = PaginationInfo.Create(page: 3, pageSize: 10);
+///
+/// EXEMPLO DE USO (com ordenação e filtros):
+///   var sortCollection = new[] { SortInfo.Create("LastName", SortDirection.Ascending) };
+///   var filterCollection = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+///   var pagination = PaginationInfo.Create(page: 1, pageSize: 20, sortCollection, filterCollection);
+///
+/// EXEMPLO DE USO (todos os registros):
+///   var allItems = PaginationInfo.All;
+///   var allSorted = PaginationInfo.All.WithSortCollection(sorts);
+///   var allFiltered = PaginationInfo.CreateAll(sorts, filters);
+///
+/// USO COM LINQ:
+///   var items = query
+///       .Where(/* aplicar filterCollection */)
+///       .OrderBy(/* aplicar sortCollection */)
+///       .Skip(pagination.Offset)
+///       .Take(pagination.PageSize)
+///       .ToList();
+///
+/// SEGURANÇA:
+/// - Os campos em Sorts e Filters devem ser validados contra uma whitelist
+///   na camada Infra.Data antes de serem usados em queries
+/// </remarks>
+public readonly struct PaginationInfo : IEquatable<PaginationInfo>
+{
+    /// <summary>
+    /// Número da página (1-indexed).
+    /// Sempre maior que zero.
+    /// </summary>
+    public int Page { get; }
+
+    /// <summary>
+    /// Quantidade de itens por página.
+    /// Sempre maior que zero.
+    /// </summary>
+    public int PageSize { get; }
+
+    /// <summary>
+    /// Índice base-zero da página.
+    /// Calculado como (Page - 1).
+    /// </summary>
+    /// <remarks>
+    /// Útil para APIs que usam índice base-zero ao invés de número de página.
+    /// Exemplo: Page 1 → Index 0, Page 2 → Index 1, Page 3 → Index 2
+    /// </remarks>
+    public int Index => Page - 1;
+
+    /// <summary>
+    /// Quantidade de itens a pular para chegar na página atual.
+    /// Calculado como (Index * PageSize) ou ((Page - 1) * PageSize).
+    /// </summary>
+    /// <remarks>
+    /// Usado diretamente com LINQ Skip() ou SQL OFFSET.
+    /// Exemplo com PageSize=10:
+    ///   Page 1 → Offset 0 (não pula nada)
+    ///   Page 2 → Offset 10 (pula 10 itens)
+    ///   Page 3 → Offset 20 (pula 20 itens)
+    /// </remarks>
+    public int Offset => Index * PageSize;
+
+    /// <summary>
+    /// Lista de ordenações a aplicar (opcional).
+    /// </summary>
+    /// <remarks>
+    /// A ordem dos itens define a prioridade da ordenação.
+    /// Exemplo: [LastName ASC, FirstName ASC] → ORDER BY LastName ASC, FirstName ASC
+    ///
+    /// SEGURANÇA: Os campos devem ser validados contra uma whitelist na camada Infra.Data.
+    /// </remarks>
+    public IReadOnlyList<SortInfo>? SortCollection { get; }
+
+    /// <summary>
+    /// Lista de filtros a aplicar (opcional).
+    /// </summary>
+    /// <remarks>
+    /// Filtros são combinados com AND por padrão.
+    ///
+    /// SEGURANÇA: Os campos devem ser validados contra uma whitelist na camada Infra.Data.
+    /// </remarks>
+    public IReadOnlyList<FilterInfo>? FilterCollection { get; }
+
+    /// <summary>
+    /// Indica se há ordenações definidas.
+    /// </summary>
+    public bool HasSort => SortCollection is not null && SortCollection.Count > 0;
+
+    /// <summary>
+    /// Indica se há filtros definidos.
+    /// </summary>
+    public bool HasFilter => FilterCollection is not null && FilterCollection.Count > 0;
+
+    /// <summary>
+    /// Indica se esta instância representa uma consulta sem limite de registros.
+    /// </summary>
+    /// <remarks>
+    /// Verdadeiro quando PageSize é int.MaxValue, indicando que o cliente
+    /// deseja todos os registros (com filtros/ordenação opcionais).
+    ///
+    /// ATENÇÃO: Queries unbounded podem retornar grandes volumes de dados.
+    /// A camada Infra.Data pode impor limites adicionais se necessário.
+    /// </remarks>
+    public bool IsUnbounded => PageSize == int.MaxValue;
+
+    private PaginationInfo(
+        int page,
+        int pageSize,
+        IReadOnlyList<SortInfo>? sortCollection,
+        IReadOnlyList<FilterInfo>? filterCollection)
+    {
+        Page = page;
+        PageSize = pageSize;
+        SortCollection = sortCollection;
+        FilterCollection = filterCollection;
+    }
+
+    /// <summary>
+    /// Retorna uma instância de PaginationInfo que representa todos os registros.
+    /// </summary>
+    /// <remarks>
+    /// Use esta propriedade quando precisar recuperar todos os registros sem paginação.
+    /// Pode ser combinada com WithSortCollection() e WithFilterCollection() para
+    /// adicionar ordenação e filtros.
+    ///
+    /// EXEMPLO DE USO:
+    ///   var allItems = PaginationInfo.All;
+    ///   var allSorted = PaginationInfo.All.WithSortCollection(sorts);
+    ///
+    /// ATENÇÃO: Use com cuidado em coleções grandes para evitar problemas de memória.
+    /// </remarks>
+    public static PaginationInfo All => CreateAll();
+
+    /// <summary>
+    /// Cria uma instância de PaginationInfo para recuperar todos os registros,
+    /// opcionalmente com ordenação e filtros.
+    /// </summary>
+    /// <param name="sortCollection">Lista de ordenações (opcional).</param>
+    /// <param name="filterCollection">Lista de filtros (opcional).</param>
+    /// <returns>PaginationInfo configurado para retornar todos os registros.</returns>
+    /// <remarks>
+    /// EXEMPLO DE USO:
+    ///   var allFiltered = PaginationInfo.CreateAll(
+    ///       sortCollection: new[] { SortInfo.Create("Name", SortDirection.Ascending) },
+    ///       filterCollection: new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") });
+    ///
+    /// ATENÇÃO: Use com cuidado em coleções grandes para evitar problemas de memória.
+    /// </remarks>
+    public static PaginationInfo CreateAll(
+        IReadOnlyList<SortInfo>? sortCollection = null,
+        IReadOnlyList<FilterInfo>? filterCollection = null)
+    {
+        return new PaginationInfo(1, int.MaxValue, sortCollection, filterCollection);
+    }
+
+    /// <summary>
+    /// Cria uma nova instância de PaginationInfo apenas com paginação.
+    /// </summary>
+    /// <param name="page">Número da página (deve ser maior que zero).</param>
+    /// <param name="pageSize">Tamanho da página (deve ser maior que zero).</param>
+    /// <returns>Nova instância de PaginationInfo.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Lançada quando page ou pageSize são menores ou iguais a zero.
+    /// </exception>
+    public static PaginationInfo Create(int page, int pageSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(page, 0, nameof(page));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(pageSize, 0, nameof(pageSize));
+
+        return new PaginationInfo(page, pageSize, null, null);
+    }
+
+    /// <summary>
+    /// Cria uma nova instância de PaginationInfo com paginação, ordenação e filtros.
+    /// </summary>
+    /// <param name="page">Número da página (deve ser maior que zero).</param>
+    /// <param name="pageSize">Tamanho da página (deve ser maior que zero).</param>
+    /// <param name="sortCollection">Lista de ordenações (opcional).</param>
+    /// <param name="filterCollection">Lista de filtros (opcional).</param>
+    /// <returns>Nova instância de PaginationInfo.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Lançada quando page ou pageSize são menores ou iguais a zero.
+    /// </exception>
+    public static PaginationInfo Create(
+        int page,
+        int pageSize,
+        IReadOnlyList<SortInfo>? sortCollection,
+        IReadOnlyList<FilterInfo>? filterCollection)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(page, 0, nameof(page));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(pageSize, 0, nameof(pageSize));
+
+        return new PaginationInfo(page, pageSize, sortCollection, filterCollection);
+    }
+
+    /// <summary>
+    /// Cria uma instância de PaginationInfo a partir de valores existentes sem validação.
+    /// </summary>
+    /// <param name="page">Número da página.</param>
+    /// <param name="pageSize">Tamanho da página.</param>
+    /// <param name="sortCollection">Lista de ordenações (opcional).</param>
+    /// <param name="filterCollection">Lista de filtros (opcional).</param>
+    /// <returns>Nova instância de PaginationInfo.</returns>
+    /// <remarks>
+    /// ATENÇÃO: Este método NÃO valida os parâmetros.
+    /// Use apenas para reconstruir PaginationInfo a partir de valores conhecidos/armazenados.
+    /// Para criar novas instâncias, use Create().
+    /// </remarks>
+    public static PaginationInfo CreateFromExistingInfo(
+        int page,
+        int pageSize,
+        IReadOnlyList<SortInfo>? sortCollection,
+        IReadOnlyList<FilterInfo>? filterCollection)
+    {
+        return new PaginationInfo(page, pageSize, sortCollection, filterCollection);
+    }
+
+    /// <summary>
+    /// Cria uma nova instância com ordenações adicionais.
+    /// </summary>
+    /// <param name="sortCollection">Lista de ordenações a adicionar.</param>
+    /// <returns>Nova instância de PaginationInfo com as ordenações.</returns>
+    public PaginationInfo WithSortCollection(IReadOnlyList<SortInfo> sortCollection)
+    {
+        return new PaginationInfo(Page, PageSize, sortCollection, FilterCollection);
+    }
+
+    /// <summary>
+    /// Cria uma nova instância com filtros adicionais.
+    /// </summary>
+    /// <param name="filterCollection">Lista de filtros a adicionar.</param>
+    /// <returns>Nova instância de PaginationInfo com os filtros.</returns>
+    public PaginationInfo WithFilterCollection(IReadOnlyList<FilterInfo> filterCollection)
+    {
+        return new PaginationInfo(Page, PageSize, SortCollection, filterCollection);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Page, PageSize);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PaginationInfo other && Equals(other);
+    }
+
+    public bool Equals(PaginationInfo other)
+    {
+        return Page == other.Page && PageSize == other.PageSize;
+    }
+
+    public override string ToString()
+    {
+        var parts = new List<string>
+        {
+            $"Page: {Page}",
+            $"PageSize: {PageSize}",
+            $"Index: {Index}",
+            $"Offset: {Offset}"
+        };
+
+        if (HasSort)
+        {
+            parts.Add($"SortCollection: [{string.Join(", ", SortCollection!)}]");
+        }
+
+        if (HasFilter)
+        {
+            parts.Add($"FilterCollection: [{string.Join(", ", FilterCollection!)}]");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    public static bool operator ==(PaginationInfo left, PaginationInfo right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(PaginationInfo left, PaginationInfo right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/src/BuildingBlocks/Core/Sortings/Enums/SortDirection.cs
+++ b/src/BuildingBlocks/Core/Sortings/Enums/SortDirection.cs
@@ -1,0 +1,17 @@
+namespace Bedrock.BuildingBlocks.Core.Sortings.Enums;
+
+/// <summary>
+/// Direção da ordenação.
+/// </summary>
+public enum SortDirection
+{
+    /// <summary>
+    /// Ordenação ascendente (A-Z, 0-9, menor para maior).
+    /// </summary>
+    Ascending = 1,
+
+    /// <summary>
+    /// Ordenação descendente (Z-A, 9-0, maior para menor).
+    /// </summary>
+    Descending = 2
+}

--- a/src/BuildingBlocks/Core/Sortings/SortInfo.cs
+++ b/src/BuildingBlocks/Core/Sortings/SortInfo.cs
@@ -1,0 +1,112 @@
+using Bedrock.BuildingBlocks.Core.Sortings.Enums;
+
+namespace Bedrock.BuildingBlocks.Core.Sortings;
+
+/// <summary>
+/// Representa informações de ordenação para uma consulta.
+/// </summary>
+/// <remarks>
+/// CARACTERÍSTICAS:
+/// - Imutável: readonly struct para performance e segurança
+/// - Validado: Field não pode ser nulo ou vazio
+///
+/// EXEMPLO DE USO:
+///   var sort = SortInfo.Create("FirstName", SortDirection.Ascending);
+///
+/// USO EM ARRAY (ordenação múltipla):
+///   var sorts = new[]
+///   {
+///       SortInfo.Create("LastName", SortDirection.Ascending),
+///       SortInfo.Create("FirstName", SortDirection.Ascending),
+///       SortInfo.Create("CreatedAt", SortDirection.Descending)
+///   };
+///   // Resultado: ORDER BY LastName ASC, FirstName ASC, CreatedAt DESC
+///
+/// SEGURANÇA:
+/// - O valor de Field deve ser validado contra uma whitelist (enum) na camada Infra.Data
+/// - Este struct apenas transporta a informação, não valida se o campo é permitido
+/// </remarks>
+public readonly struct SortInfo : IEquatable<SortInfo>
+{
+    /// <summary>
+    /// Nome do campo para ordenação.
+    /// </summary>
+    /// <remarks>
+    /// Este valor deve ser validado contra uma whitelist de campos permitidos
+    /// na camada Infra.Data antes de ser usado em queries.
+    /// </remarks>
+    public string Field { get; }
+
+    /// <summary>
+    /// Direção da ordenação (Ascending ou Descending).
+    /// </summary>
+    public SortDirection Direction { get; }
+
+    private SortInfo(string field, SortDirection direction)
+    {
+        Field = field;
+        Direction = direction;
+    }
+
+    /// <summary>
+    /// Cria uma nova instância de SortInfo com validação.
+    /// </summary>
+    /// <param name="field">Nome do campo para ordenação (não pode ser nulo ou vazio).</param>
+    /// <param name="direction">Direção da ordenação.</param>
+    /// <returns>Nova instância de SortInfo.</returns>
+    /// <exception cref="ArgumentException">
+    /// Lançada quando field é nulo ou vazio.
+    /// </exception>
+    public static SortInfo Create(string field, SortDirection direction)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field, nameof(field));
+
+        return new SortInfo(field, direction);
+    }
+
+    /// <summary>
+    /// Cria uma instância de SortInfo a partir de valores existentes sem validação.
+    /// </summary>
+    /// <param name="field">Nome do campo para ordenação.</param>
+    /// <param name="direction">Direção da ordenação.</param>
+    /// <returns>Nova instância de SortInfo.</returns>
+    /// <remarks>
+    /// ATENÇÃO: Este método NÃO valida os parâmetros.
+    /// Use apenas para reconstruir SortInfo a partir de valores conhecidos/armazenados.
+    /// Para criar novas instâncias, use Create().
+    /// </remarks>
+    public static SortInfo CreateFromExistingInfo(string field, SortDirection direction)
+    {
+        return new SortInfo(field, direction);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Field, Direction);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is SortInfo other && Equals(other);
+    }
+
+    public bool Equals(SortInfo other)
+    {
+        return Field == other.Field && Direction == other.Direction;
+    }
+
+    public override string ToString()
+    {
+        return $"{Field} {Direction}";
+    }
+
+    public static bool operator ==(SortInfo left, SortInfo right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SortInfo left, SortInfo right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Filterings/Enums/FilterOperatorTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Filterings/Enums/FilterOperatorTests.cs
@@ -1,0 +1,117 @@
+using Bedrock.BuildingBlocks.Core.Filterings.Enums;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Filterings.Enums;
+
+public class FilterOperatorTests : TestBase
+{
+    public FilterOperatorTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Theory]
+    [InlineData(FilterOperator.Equals, 1)]
+    [InlineData(FilterOperator.NotEquals, 2)]
+    [InlineData(FilterOperator.Contains, 3)]
+    [InlineData(FilterOperator.StartsWith, 4)]
+    [InlineData(FilterOperator.EndsWith, 5)]
+    [InlineData(FilterOperator.GreaterThan, 6)]
+    [InlineData(FilterOperator.GreaterThanOrEquals, 7)]
+    [InlineData(FilterOperator.LessThan, 8)]
+    [InlineData(FilterOperator.LessThanOrEquals, 9)]
+    [InlineData(FilterOperator.Between, 10)]
+    [InlineData(FilterOperator.In, 11)]
+    [InlineData(FilterOperator.NotIn, 12)]
+    public void FilterOperator_ShouldHaveCorrectValue(FilterOperator op, int expectedValue)
+    {
+        // Arrange
+        LogArrange("Getting enum value");
+        LogInfo("Operator: {0}", op);
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)op;
+
+        // Assert
+        LogAssert("Verifying value");
+        value.ShouldBe(expectedValue);
+        LogInfo("{0} = {1}", op, value);
+    }
+
+    [Fact]
+    public void FilterOperator_ShouldHaveExactly12Values()
+    {
+        // Arrange
+        LogArrange("Getting all enum values");
+
+        // Act
+        LogAct("Counting enum values");
+        var values = Enum.GetValues<FilterOperator>();
+
+        // Assert
+        LogAssert("Verifying count is 12");
+        values.Length.ShouldBe(12);
+        LogInfo("FilterOperator has {0} values", values.Length);
+    }
+
+    [Theory]
+    [InlineData(FilterOperator.Equals, "Equals")]
+    [InlineData(FilterOperator.NotEquals, "NotEquals")]
+    [InlineData(FilterOperator.Contains, "Contains")]
+    [InlineData(FilterOperator.StartsWith, "StartsWith")]
+    [InlineData(FilterOperator.EndsWith, "EndsWith")]
+    [InlineData(FilterOperator.GreaterThan, "GreaterThan")]
+    [InlineData(FilterOperator.GreaterThanOrEquals, "GreaterThanOrEquals")]
+    [InlineData(FilterOperator.LessThan, "LessThan")]
+    [InlineData(FilterOperator.LessThanOrEquals, "LessThanOrEquals")]
+    [InlineData(FilterOperator.Between, "Between")]
+    [InlineData(FilterOperator.In, "In")]
+    [InlineData(FilterOperator.NotIn, "NotIn")]
+    public void FilterOperator_ToString_ShouldReturnName(FilterOperator op, string expectedName)
+    {
+        // Arrange
+        LogArrange("Getting ToString");
+        LogInfo("Operator: {0}", op);
+
+        // Act
+        LogAct("Calling ToString");
+        var name = op.ToString();
+
+        // Assert
+        LogAssert("Verifying name");
+        name.ShouldBe(expectedName);
+        LogInfo("{0}.ToString() = {1}", op, name);
+    }
+
+    [Theory]
+    [InlineData("Equals", FilterOperator.Equals)]
+    [InlineData("NotEquals", FilterOperator.NotEquals)]
+    [InlineData("Contains", FilterOperator.Contains)]
+    [InlineData("StartsWith", FilterOperator.StartsWith)]
+    [InlineData("EndsWith", FilterOperator.EndsWith)]
+    [InlineData("GreaterThan", FilterOperator.GreaterThan)]
+    [InlineData("GreaterThanOrEquals", FilterOperator.GreaterThanOrEquals)]
+    [InlineData("LessThan", FilterOperator.LessThan)]
+    [InlineData("LessThanOrEquals", FilterOperator.LessThanOrEquals)]
+    [InlineData("Between", FilterOperator.Between)]
+    [InlineData("In", FilterOperator.In)]
+    [InlineData("NotIn", FilterOperator.NotIn)]
+    public void FilterOperator_Parse_ShouldWork(string name, FilterOperator expected)
+    {
+        // Arrange
+        LogArrange("Parsing enum");
+        LogInfo("Name: {0}", name);
+
+        // Act
+        LogAct("Parsing enum");
+        var parsed = Enum.Parse<FilterOperator>(name);
+
+        // Assert
+        LogAssert("Verifying parsed value");
+        parsed.ShouldBe(expected);
+        LogInfo("Parsed {0} = {1}", name, parsed);
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Filterings/FilterInfoTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Filterings/FilterInfoTests.cs
@@ -1,0 +1,638 @@
+using Bedrock.BuildingBlocks.Core.Filterings;
+using Bedrock.BuildingBlocks.Core.Filterings.Enums;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Filterings;
+
+public class FilterInfoTests : TestBase
+{
+    public FilterInfoTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    #region Create Tests
+
+    [Fact]
+    public void Create_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up filter info components");
+        var field = "LastName";
+        var op = FilterOperator.Contains;
+        var value = "Silva";
+
+        // Act
+        LogAct("Creating FilterInfo");
+        var filter = FilterInfo.Create(field, op, value);
+
+        // Assert
+        LogAssert("Verifying all properties are set");
+        filter.Field.ShouldBe(field);
+        filter.Operator.ShouldBe(op);
+        filter.Value.ShouldBe(value);
+        filter.ValueEnd.ShouldBeNull();
+        filter.Values.ShouldBeNull();
+        LogInfo("FilterInfo created: {0}", filter);
+    }
+
+    [Fact]
+    public void Create_WithNullValue_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Setting up filter with null value");
+
+        // Act
+        LogAct("Creating FilterInfo with null value");
+        var filter = FilterInfo.Create("Status", FilterOperator.Equals, null);
+
+        // Assert
+        LogAssert("Verifying null value accepted");
+        filter.Value.ShouldBeNull();
+        LogInfo("FilterInfo with null value: {0}", filter);
+    }
+
+    [Fact]
+    public void Create_WithNullField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing null field");
+
+        // Act & Assert
+        LogAct("Creating FilterInfo with null field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.Create(null!, FilterOperator.Equals, "value"));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    [Fact]
+    public void Create_WithEmptyField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing empty field");
+
+        // Act & Assert
+        LogAct("Creating FilterInfo with empty field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.Create("", FilterOperator.Equals, "value"));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing whitespace field");
+
+        // Act & Assert
+        LogAct("Creating FilterInfo with whitespace field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.Create("   ", FilterOperator.Contains, "value"));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    #endregion
+
+    #region CreateBetween Tests
+
+    [Fact]
+    public void CreateBetween_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up between filter");
+        var field = "CreatedAt";
+        var valueStart = "2024-01-01";
+        var valueEnd = "2024-12-31";
+
+        // Act
+        LogAct("Creating Between FilterInfo");
+        var filter = FilterInfo.CreateBetween(field, valueStart, valueEnd);
+
+        // Assert
+        LogAssert("Verifying properties");
+        filter.Field.ShouldBe(field);
+        filter.Operator.ShouldBe(FilterOperator.Between);
+        filter.Value.ShouldBe(valueStart);
+        filter.ValueEnd.ShouldBe(valueEnd);
+        filter.Values.ShouldBeNull();
+        LogInfo("Between filter: {0}", filter);
+    }
+
+    [Fact]
+    public void CreateBetween_WithNullField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing null field for between");
+
+        // Act & Assert
+        LogAct("Creating Between with null field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.CreateBetween(null!, "start", "end"));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+    }
+
+    [Fact]
+    public void CreateBetween_WithNullValues_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating between with null values");
+
+        // Act
+        LogAct("Creating Between with nulls");
+        var filter = FilterInfo.CreateBetween("Date", null, null);
+
+        // Assert
+        LogAssert("Verifying null values accepted");
+        filter.Value.ShouldBeNull();
+        filter.ValueEnd.ShouldBeNull();
+        LogInfo("Between with nulls: {0}", filter);
+    }
+
+    #endregion
+
+    #region CreateIn Tests
+
+    [Fact]
+    public void CreateIn_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up In filter");
+        var field = "Status";
+        var values = new[] { "Active", "Pending" };
+
+        // Act
+        LogAct("Creating In FilterInfo");
+        var filter = FilterInfo.CreateIn(field, values);
+
+        // Assert
+        LogAssert("Verifying properties");
+        filter.Field.ShouldBe(field);
+        filter.Operator.ShouldBe(FilterOperator.In);
+        filter.Value.ShouldBeNull();
+        filter.ValueEnd.ShouldBeNull();
+        filter.Values.ShouldBe(values);
+        LogInfo("In filter: {0}", filter);
+    }
+
+    [Fact]
+    public void CreateIn_WithNullField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing null field for In");
+
+        // Act & Assert
+        LogAct("Creating In with null field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.CreateIn(null!, new[] { "value" }));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+    }
+
+    #endregion
+
+    #region CreateNotIn Tests
+
+    [Fact]
+    public void CreateNotIn_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up NotIn filter");
+        var field = "Status";
+        var values = new[] { "Deleted", "Archived" };
+
+        // Act
+        LogAct("Creating NotIn FilterInfo");
+        var filter = FilterInfo.CreateNotIn(field, values);
+
+        // Assert
+        LogAssert("Verifying properties");
+        filter.Field.ShouldBe(field);
+        filter.Operator.ShouldBe(FilterOperator.NotIn);
+        filter.Value.ShouldBeNull();
+        filter.ValueEnd.ShouldBeNull();
+        filter.Values.ShouldBe(values);
+        LogInfo("NotIn filter: {0}", filter);
+    }
+
+    [Fact]
+    public void CreateNotIn_WithNullField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing null field for NotIn");
+
+        // Act & Assert
+        LogAct("Creating NotIn with null field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            FilterInfo.CreateNotIn(null!, new[] { "value" }));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+    }
+
+    #endregion
+
+    #region CreateFromExistingInfo Tests
+
+    [Fact]
+    public void CreateFromExistingInfo_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up existing info");
+        var field = "Field";
+        var op = FilterOperator.Contains;
+        var value = "value";
+        var valueEnd = "end";
+        var values = new[] { "a", "b" };
+
+        // Act
+        LogAct("Creating from existing info");
+        var filter = FilterInfo.CreateFromExistingInfo(field, op, value, valueEnd, values);
+
+        // Assert
+        LogAssert("Verifying all properties");
+        filter.Field.ShouldBe(field);
+        filter.Operator.ShouldBe(op);
+        filter.Value.ShouldBe(value);
+        filter.ValueEnd.ShouldBe(valueEnd);
+        filter.Values.ShouldBe(values);
+        LogInfo("Filter from existing: {0}", filter);
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_WithEmptyField_ShouldNotThrow()
+    {
+        // Arrange
+        LogArrange("Preparing empty field for existing info");
+
+        // Act
+        LogAct("Creating from existing with empty field");
+        var filter = FilterInfo.CreateFromExistingInfo("", FilterOperator.Equals, null, null, null);
+
+        // Assert
+        LogAssert("Verifying no exception");
+        filter.Field.ShouldBe("");
+        LogInfo("Empty field accepted");
+    }
+
+    #endregion
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equals_WithSameValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two FilterInfos with same values");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = filter1.Equals(filter2);
+
+        // Assert
+        LogAssert("Verifying equality");
+        areEqual.ShouldBeTrue();
+        LogInfo("FilterInfos are equal");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentField_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos with different fields");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Email", FilterOperator.Contains, "test");
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = filter1.Equals(filter2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithDifferentOperator_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos with different operators");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Name", FilterOperator.Equals, "test");
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = filter1.Equals(filter2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValue_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos with different values");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test1");
+        var filter2 = FilterInfo.Create("Name", FilterOperator.Contains, "test2");
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = filter1.Equals(filter2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValueEnd_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating Between filters with different ValueEnd");
+        var filter1 = FilterInfo.CreateBetween("Date", "2024-01-01", "2024-06-30");
+        var filter2 = FilterInfo.CreateBetween("Date", "2024-01-01", "2024-12-31");
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = filter1.Equals(filter2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithObjectParameter_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfo and objects for equality test");
+        var filter = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        object objSame = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        object objDifferent = FilterInfo.Create("Email", FilterOperator.Contains, "test");
+        object? objNull = null;
+        object objWrongType = "not a filter";
+
+        // Act & Assert
+        LogAct("Testing Equals with various object types");
+        filter.Equals(objSame).ShouldBeTrue();
+        filter.Equals(objDifferent).ShouldBeFalse();
+        filter.Equals(objNull).ShouldBeFalse();
+        filter.Equals(objWrongType).ShouldBeFalse();
+        LogAssert("Object equality tests passed");
+    }
+
+    [Fact]
+    public void EqualityOperator_WithSameValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two FilterInfos with same values");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+
+        // Act & Assert
+        LogAct("Testing equality operator");
+        (filter1 == filter2).ShouldBeTrue();
+        LogAssert("Equality operator works correctly");
+    }
+
+    [Fact]
+    public void InequalityOperator_WithDifferentValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two different FilterInfos");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Email", FilterOperator.Equals, "other");
+
+        // Act & Assert
+        LogAct("Testing inequality operator");
+        (filter1 != filter2).ShouldBeTrue();
+        LogAssert("Inequality operator works correctly");
+    }
+
+    #endregion
+
+    #region GetHashCode Tests
+
+    [Fact]
+    public void GetHashCode_SameValues_ShouldReturnSameHash()
+    {
+        // Arrange
+        LogArrange("Creating two FilterInfos with same values");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = filter1.GetHashCode();
+        var hash2 = filter2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are equal");
+        hash1.ShouldBe(hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentValues_ShouldReturnDifferentHash()
+    {
+        // Arrange
+        LogArrange("Creating two different FilterInfos");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2 = FilterInfo.Create("Email", FilterOperator.Equals, "other");
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = filter1.GetHashCode();
+        var hash2 = filter2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are different");
+        hash1.ShouldNotBe(hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldCombineAllRelevantFields()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos differing in single fields");
+        var baseFilter = FilterInfo.CreateBetween("Date", "2024-01-01", "2024-12-31");
+        var diffField = FilterInfo.CreateBetween("Time", "2024-01-01", "2024-12-31");
+        var diffValue = FilterInfo.CreateBetween("Date", "2023-01-01", "2024-12-31");
+        var diffValueEnd = FilterInfo.CreateBetween("Date", "2024-01-01", "2025-12-31");
+
+        // Act
+        LogAct("Getting hash codes");
+        var baseHash = baseFilter.GetHashCode();
+        var fieldHash = diffField.GetHashCode();
+        var valueHash = diffValue.GetHashCode();
+        var valueEndHash = diffValueEnd.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying all fields contribute to hash");
+        baseHash.ShouldNotBe(fieldHash, "Field should affect hash");
+        baseHash.ShouldNotBe(valueHash, "Value should affect hash");
+        baseHash.ShouldNotBe(valueEndHash, "ValueEnd should affect hash");
+    }
+
+    #endregion
+
+    #region ToString Tests
+
+    [Fact]
+    public void ToString_SimpleFilter_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating simple filter");
+        var filter = FilterInfo.Create("Name", FilterOperator.Contains, "Silva");
+
+        // Act
+        LogAct("Calling ToString");
+        var result = filter.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("Name Contains Silva");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_BetweenFilter_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating between filter");
+        var filter = FilterInfo.CreateBetween("CreatedAt", "2024-01-01", "2024-12-31");
+
+        // Act
+        LogAct("Calling ToString");
+        var result = filter.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("CreatedAt Between [2024-01-01, 2024-12-31]");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_InFilter_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating In filter");
+        var filter = FilterInfo.CreateIn("Status", new[] { "Active", "Pending" });
+
+        // Act
+        LogAct("Calling ToString");
+        var result = filter.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("Status In [Active, Pending]");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_NotInFilter_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating NotIn filter");
+        var filter = FilterInfo.CreateNotIn("Status", new[] { "Deleted" });
+
+        // Act
+        LogAct("Calling ToString");
+        var result = filter.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("Status NotIn [Deleted]");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_InFilterWithEmptyValues_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating In filter with empty values via CreateFromExistingInfo");
+        var filter = FilterInfo.CreateFromExistingInfo("Status", FilterOperator.In, null, null, null);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = filter.ToString();
+
+        // Assert
+        LogAssert("Verifying format with empty values");
+        result.ShouldBe("Status In []");
+        LogInfo("ToString: {0}", result);
+    }
+
+    #endregion
+
+    #region Mutation Killing Tests
+
+    [Fact]
+    public void Equals_AllFieldsMustMatch()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos for comprehensive equality check");
+        var reference = FilterInfo.CreateBetween("Date", "start", "end");
+
+        var diffFieldOnly = FilterInfo.CreateBetween("Time", "start", "end");
+        var diffValueOnly = FilterInfo.CreateBetween("Date", "other", "end");
+        var diffValueEndOnly = FilterInfo.CreateBetween("Date", "start", "other");
+
+        // Act & Assert
+        LogAct("Verifying each field affects equality");
+        reference.Equals(diffFieldOnly).ShouldBeFalse("Field must affect equality");
+        reference.Equals(diffValueOnly).ShouldBeFalse("Value must affect equality");
+        reference.Equals(diffValueEndOnly).ShouldBeFalse("ValueEnd must affect equality");
+        LogAssert("All equality conditions verified");
+    }
+
+    [Fact]
+    public void Equals_OperatorMustMatch()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos with different operators");
+        var filter1 = FilterInfo.Create("Field", FilterOperator.Equals, "value");
+        var filter2 = FilterInfo.Create("Field", FilterOperator.NotEquals, "value");
+
+        // Act & Assert
+        LogAct("Verifying operator affects equality");
+        filter1.Equals(filter2).ShouldBeFalse("Operator must affect equality");
+        LogAssert("Operator equality verified");
+    }
+
+    [Fact]
+    public void InequalityOperator_ShouldNegateEquals()
+    {
+        // Arrange
+        LogArrange("Creating FilterInfos for inequality check");
+        var filter1 = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter2Same = FilterInfo.Create("Name", FilterOperator.Contains, "test");
+        var filter3Diff = FilterInfo.Create("Email", FilterOperator.Equals, "other");
+
+        // Act & Assert
+        LogAct("Verifying != negates ==");
+        (filter1 == filter2Same).ShouldBeTrue();
+        (filter1 != filter2Same).ShouldBeFalse();
+        (filter1 == filter3Diff).ShouldBeFalse();
+        (filter1 != filter3Diff).ShouldBeTrue();
+        LogAssert("Inequality operator correctly negates equality");
+    }
+
+    #endregion
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Paginations/PaginationInfoTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Paginations/PaginationInfoTests.cs
@@ -1,0 +1,861 @@
+using Bedrock.BuildingBlocks.Core.Filterings;
+using Bedrock.BuildingBlocks.Core.Filterings.Enums;
+using Bedrock.BuildingBlocks.Core.Paginations;
+using Bedrock.BuildingBlocks.Core.Sortings;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using SortDirection = Bedrock.BuildingBlocks.Core.Sortings.Enums.SortDirection;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Paginations;
+
+public class PaginationInfoTests : TestBase
+{
+    public PaginationInfoTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    #region Create Tests
+
+    [Fact]
+    public void Create_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up pagination");
+        var page = 3;
+        var pageSize = 10;
+
+        // Act
+        LogAct("Creating PaginationInfo");
+        var pagination = PaginationInfo.Create(page, pageSize);
+
+        // Assert
+        LogAssert("Verifying all properties");
+        pagination.Page.ShouldBe(page);
+        pagination.PageSize.ShouldBe(pageSize);
+        pagination.Index.ShouldBe(2); // Page - 1
+        pagination.Offset.ShouldBe(20); // Index * PageSize
+        pagination.SortCollection.ShouldBeNull();
+        pagination.FilterCollection.ShouldBeNull();
+        pagination.HasSort.ShouldBeFalse();
+        pagination.HasFilter.ShouldBeFalse();
+        pagination.IsUnbounded.ShouldBeFalse();
+        LogInfo("Pagination: {0}", pagination);
+    }
+
+    [Theory]
+    [InlineData(1, 10, 0, 0)]
+    [InlineData(2, 10, 1, 10)]
+    [InlineData(3, 10, 2, 20)]
+    [InlineData(1, 20, 0, 0)]
+    [InlineData(5, 20, 4, 80)]
+    public void Create_ShouldCalculateIndexAndOffsetCorrectly(int page, int pageSize, int expectedIndex, int expectedOffset)
+    {
+        // Arrange
+        LogArrange("Creating pagination");
+        LogInfo("page={0}, pageSize={1}", page, pageSize);
+
+        // Act
+        LogAct("Creating PaginationInfo");
+        var pagination = PaginationInfo.Create(page, pageSize);
+
+        // Assert
+        LogAssert("Verifying Index and Offset");
+        pagination.Index.ShouldBe(expectedIndex);
+        pagination.Offset.ShouldBe(expectedOffset);
+        LogInfo("Index={0}, Offset={1}", pagination.Index, pagination.Offset);
+    }
+
+    [Fact]
+    public void Create_WithZeroPage_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing zero page");
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with zero page");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(0, 10));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("page");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    [Fact]
+    public void Create_WithNegativePage_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing negative page");
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with negative page");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(-1, 10));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("page");
+    }
+
+    [Fact]
+    public void Create_WithZeroPageSize_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing zero pageSize");
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with zero pageSize");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(1, 0));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("pageSize");
+    }
+
+    [Fact]
+    public void Create_WithNegativePageSize_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing negative pageSize");
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with negative pageSize");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(1, -10));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("pageSize");
+    }
+
+    #endregion
+
+    #region Create With Collections Tests
+
+    [Fact]
+    public void Create_WithCollections_ZeroPage_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing zero page with collections");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with zero page");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(0, 10, sorts, null));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("page");
+    }
+
+    [Fact]
+    public void Create_WithCollections_ZeroPageSize_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        LogArrange("Preparing zero pageSize with collections");
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+
+        // Act & Assert
+        LogAct("Creating PaginationInfo with zero pageSize");
+        var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            PaginationInfo.Create(1, 0, null, filters));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("pageSize");
+    }
+
+    [Fact]
+    public void Create_WithSortAndFilter_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up pagination with sort and filter");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+
+        // Act
+        LogAct("Creating PaginationInfo with collections");
+        var pagination = PaginationInfo.Create(1, 20, sorts, filters);
+
+        // Assert
+        LogAssert("Verifying collections");
+        pagination.SortCollection.ShouldBe(sorts);
+        pagination.FilterCollection.ShouldBe(filters);
+        pagination.HasSort.ShouldBeTrue();
+        pagination.HasFilter.ShouldBeTrue();
+        LogInfo("Pagination with collections: {0}", pagination);
+    }
+
+    [Fact]
+    public void Create_WithNullCollections_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Setting up pagination with null collections");
+
+        // Act
+        LogAct("Creating PaginationInfo with null collections");
+        var pagination = PaginationInfo.Create(1, 20, null, null);
+
+        // Assert
+        LogAssert("Verifying null collections");
+        pagination.SortCollection.ShouldBeNull();
+        pagination.FilterCollection.ShouldBeNull();
+        pagination.HasSort.ShouldBeFalse();
+        pagination.HasFilter.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Create_WithEmptyCollections_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Setting up pagination with empty collections");
+        var sorts = Array.Empty<SortInfo>();
+        var filters = Array.Empty<FilterInfo>();
+
+        // Act
+        LogAct("Creating PaginationInfo with empty collections");
+        var pagination = PaginationInfo.Create(1, 20, sorts, filters);
+
+        // Assert
+        LogAssert("Verifying empty collections");
+        pagination.SortCollection.ShouldBe(sorts);
+        pagination.FilterCollection.ShouldBe(filters);
+        pagination.HasSort.ShouldBeFalse();
+        pagination.HasFilter.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region All and CreateAll Tests
+
+    [Fact]
+    public void All_ShouldReturnUnboundedPagination()
+    {
+        // Arrange
+        LogArrange("Getting All pagination");
+
+        // Act
+        LogAct("Accessing PaginationInfo.All");
+        var pagination = PaginationInfo.All;
+
+        // Assert
+        LogAssert("Verifying unbounded pagination");
+        pagination.Page.ShouldBe(1);
+        pagination.PageSize.ShouldBe(int.MaxValue);
+        pagination.IsUnbounded.ShouldBeTrue();
+        pagination.SortCollection.ShouldBeNull();
+        pagination.FilterCollection.ShouldBeNull();
+        LogInfo("All pagination: {0}", pagination);
+    }
+
+    [Fact]
+    public void CreateAll_ShouldReturnUnboundedPagination()
+    {
+        // Arrange
+        LogArrange("Creating All pagination");
+
+        // Act
+        LogAct("Calling CreateAll");
+        var pagination = PaginationInfo.CreateAll();
+
+        // Assert
+        LogAssert("Verifying unbounded pagination");
+        pagination.Page.ShouldBe(1);
+        pagination.PageSize.ShouldBe(int.MaxValue);
+        pagination.IsUnbounded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreateAll_WithCollections_ShouldSetCollections()
+    {
+        // Arrange
+        LogArrange("Creating All with collections");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Active", FilterOperator.Equals, "true") };
+
+        // Act
+        LogAct("Calling CreateAll with collections");
+        var pagination = PaginationInfo.CreateAll(sorts, filters);
+
+        // Assert
+        LogAssert("Verifying collections on unbounded");
+        pagination.IsUnbounded.ShouldBeTrue();
+        pagination.SortCollection.ShouldBe(sorts);
+        pagination.FilterCollection.ShouldBe(filters);
+        pagination.HasSort.ShouldBeTrue();
+        pagination.HasFilter.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region CreateFromExistingInfo Tests
+
+    [Fact]
+    public void CreateFromExistingInfo_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up existing info");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+
+        // Act
+        LogAct("Creating from existing info");
+        var pagination = PaginationInfo.CreateFromExistingInfo(2, 15, sorts, filters);
+
+        // Assert
+        LogAssert("Verifying all properties");
+        pagination.Page.ShouldBe(2);
+        pagination.PageSize.ShouldBe(15);
+        pagination.SortCollection.ShouldBe(sorts);
+        pagination.FilterCollection.ShouldBe(filters);
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_WithInvalidValues_ShouldNotThrow()
+    {
+        // Arrange
+        LogArrange("Preparing invalid values for existing info");
+
+        // Act
+        LogAct("Creating from existing with zero page");
+        var pagination = PaginationInfo.CreateFromExistingInfo(0, 0, null, null);
+
+        // Assert
+        LogAssert("Verifying no exception");
+        pagination.Page.ShouldBe(0);
+        pagination.PageSize.ShouldBe(0);
+        LogInfo("Invalid values accepted in CreateFromExistingInfo");
+    }
+
+    #endregion
+
+    #region With Methods Tests
+
+    [Fact]
+    public void WithSortCollection_ShouldReturnNewInstanceWithSorts()
+    {
+        // Arrange
+        LogArrange("Creating pagination and sorts");
+        var pagination = PaginationInfo.Create(1, 10);
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+
+        // Act
+        LogAct("Adding sort collection");
+        var newPagination = pagination.WithSortCollection(sorts);
+
+        // Assert
+        LogAssert("Verifying new instance");
+        newPagination.SortCollection.ShouldBe(sorts);
+        newPagination.HasSort.ShouldBeTrue();
+        newPagination.Page.ShouldBe(pagination.Page);
+        newPagination.PageSize.ShouldBe(pagination.PageSize);
+        pagination.SortCollection.ShouldBeNull(); // Original unchanged
+    }
+
+    [Fact]
+    public void WithFilterCollection_ShouldReturnNewInstanceWithFilters()
+    {
+        // Arrange
+        LogArrange("Creating pagination and filters");
+        var pagination = PaginationInfo.Create(1, 10);
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+
+        // Act
+        LogAct("Adding filter collection");
+        var newPagination = pagination.WithFilterCollection(filters);
+
+        // Assert
+        LogAssert("Verifying new instance");
+        newPagination.FilterCollection.ShouldBe(filters);
+        newPagination.HasFilter.ShouldBeTrue();
+        newPagination.Page.ShouldBe(pagination.Page);
+        newPagination.PageSize.ShouldBe(pagination.PageSize);
+        pagination.FilterCollection.ShouldBeNull(); // Original unchanged
+    }
+
+    [Fact]
+    public void WithSortCollection_OnAll_ShouldReturnUnboundedWithSorts()
+    {
+        // Arrange
+        LogArrange("Creating All pagination");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+
+        // Act
+        LogAct("Adding sorts to All");
+        var pagination = PaginationInfo.All.WithSortCollection(sorts);
+
+        // Assert
+        LogAssert("Verifying unbounded with sorts");
+        pagination.IsUnbounded.ShouldBeTrue();
+        pagination.HasSort.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WithFilterCollection_PreservesSortCollection()
+    {
+        // Arrange
+        LogArrange("Creating pagination with sorts");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+        var pagination = PaginationInfo.Create(1, 10, sorts, null);
+
+        // Act
+        LogAct("Adding filters");
+        var newPagination = pagination.WithFilterCollection(filters);
+
+        // Assert
+        LogAssert("Verifying sorts preserved");
+        newPagination.SortCollection.ShouldBe(sorts);
+        newPagination.FilterCollection.ShouldBe(filters);
+    }
+
+    [Fact]
+    public void WithSortCollection_PreservesFilterCollection()
+    {
+        // Arrange
+        LogArrange("Creating pagination with filters");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+        var pagination = PaginationInfo.Create(1, 10, null, filters);
+
+        // Act
+        LogAct("Adding sorts");
+        var newPagination = pagination.WithSortCollection(sorts);
+
+        // Assert
+        LogAssert("Verifying filters preserved");
+        newPagination.SortCollection.ShouldBe(sorts);
+        newPagination.FilterCollection.ShouldBe(filters);
+    }
+
+    #endregion
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equals_WithSamePageAndPageSize_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two PaginationInfos with same values");
+        var pagination1 = PaginationInfo.Create(2, 20);
+        var pagination2 = PaginationInfo.Create(2, 20);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = pagination1.Equals(pagination2);
+
+        // Assert
+        LogAssert("Verifying equality");
+        areEqual.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_WithDifferentPage_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos with different pages");
+        var pagination1 = PaginationInfo.Create(1, 20);
+        var pagination2 = PaginationInfo.Create(2, 20);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = pagination1.Equals(pagination2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithDifferentPageSize_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos with different pageSizes");
+        var pagination1 = PaginationInfo.Create(1, 10);
+        var pagination2 = PaginationInfo.Create(1, 20);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = pagination1.Equals(pagination2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_IgnoresSortAndFilterCollections()
+    {
+        // Arrange - equality is based only on Page and PageSize
+        LogArrange("Creating PaginationInfos with same page/size but different collections");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var pagination1 = PaginationInfo.Create(1, 10);
+        var pagination2 = PaginationInfo.Create(1, 10, sorts, null);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = pagination1.Equals(pagination2);
+
+        // Assert
+        LogAssert("Verifying equality ignores collections");
+        areEqual.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_WithObjectParameter_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfo and objects");
+        var pagination = PaginationInfo.Create(1, 10);
+        object objSame = PaginationInfo.Create(1, 10);
+        object objDifferent = PaginationInfo.Create(2, 20);
+        object? objNull = null;
+        object objWrongType = "not a pagination";
+
+        // Act & Assert
+        LogAct("Testing Equals with various object types");
+        pagination.Equals(objSame).ShouldBeTrue();
+        pagination.Equals(objDifferent).ShouldBeFalse();
+        pagination.Equals(objNull).ShouldBeFalse();
+        pagination.Equals(objWrongType).ShouldBeFalse();
+        LogAssert("Object equality tests passed");
+    }
+
+    [Fact]
+    public void EqualityOperator_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos");
+        var pagination1 = PaginationInfo.Create(1, 10);
+        var pagination2 = PaginationInfo.Create(1, 10);
+        var pagination3 = PaginationInfo.Create(2, 20);
+
+        // Act & Assert
+        LogAct("Testing operators");
+        (pagination1 == pagination2).ShouldBeTrue();
+        (pagination1 != pagination3).ShouldBeTrue();
+        LogAssert("Operators work correctly");
+    }
+
+    #endregion
+
+    #region GetHashCode Tests
+
+    [Fact]
+    public void GetHashCode_SameValues_ShouldReturnSameHash()
+    {
+        // Arrange
+        LogArrange("Creating two PaginationInfos with same values");
+        var pagination1 = PaginationInfo.Create(2, 20);
+        var pagination2 = PaginationInfo.Create(2, 20);
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = pagination1.GetHashCode();
+        var hash2 = pagination2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are equal");
+        hash1.ShouldBe(hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentValues_ShouldReturnDifferentHash()
+    {
+        // Arrange
+        LogArrange("Creating two different PaginationInfos");
+        var pagination1 = PaginationInfo.Create(1, 10);
+        var pagination2 = PaginationInfo.Create(2, 20);
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = pagination1.GetHashCode();
+        var hash2 = pagination2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are different");
+        hash1.ShouldNotBe(hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldCombinePageAndPageSize()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos differing in single fields");
+        var basePagination = PaginationInfo.Create(1, 10);
+        var diffPage = PaginationInfo.Create(2, 10);
+        var diffPageSize = PaginationInfo.Create(1, 20);
+
+        // Act
+        LogAct("Getting hash codes");
+        var baseHash = basePagination.GetHashCode();
+        var pageHash = diffPage.GetHashCode();
+        var pageSizeHash = diffPageSize.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying both fields contribute to hash");
+        baseHash.ShouldNotBe(pageHash, "Page should affect hash");
+        baseHash.ShouldNotBe(pageSizeHash, "PageSize should affect hash");
+    }
+
+    #endregion
+
+    #region ToString Tests
+
+    [Fact]
+    public void ToString_BasicPagination_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating basic pagination");
+        var pagination = PaginationInfo.Create(3, 10);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldContain("Page: 3");
+        result.ShouldContain("PageSize: 10");
+        result.ShouldContain("Index: 2");
+        result.ShouldContain("Offset: 20");
+        result.ShouldNotContain("SortCollection");
+        result.ShouldNotContain("FilterCollection");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_WithSort_ShouldIncludeSortCollection()
+    {
+        // Arrange
+        LogArrange("Creating pagination with sort");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var pagination = PaginationInfo.Create(1, 10, sorts, null);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert
+        LogAssert("Verifying sort in output");
+        result.ShouldContain("SortCollection: [");
+        result.ShouldContain("Name Ascending");
+        result.ShouldContain("]");
+    }
+
+    [Fact]
+    public void ToString_WithFilter_ShouldIncludeFilterCollection()
+    {
+        // Arrange
+        LogArrange("Creating pagination with filter");
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+        var pagination = PaginationInfo.Create(1, 10, null, filters);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert
+        LogAssert("Verifying filter in output");
+        result.ShouldContain("FilterCollection: [");
+        result.ShouldContain("Status Equals Active");
+        result.ShouldContain("]");
+    }
+
+    [Fact]
+    public void ToString_WithBothCollections_ShouldIncludeBoth()
+    {
+        // Arrange
+        LogArrange("Creating pagination with both collections");
+        var sorts = new[] { SortInfo.Create("Name", SortDirection.Ascending) };
+        var filters = new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") };
+        var pagination = PaginationInfo.Create(1, 10, sorts, filters);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert
+        LogAssert("Verifying both collections in output");
+        result.ShouldContain("SortCollection: [Name Ascending]");
+        result.ShouldContain("FilterCollection: [Status Equals Active]");
+        // Verify comma separator
+        result.ShouldContain(", ");
+    }
+
+    [Fact]
+    public void ToString_PartsJoinedWithComma()
+    {
+        // Arrange - mata mutante de string.Join separador
+        LogArrange("Creating pagination for join verification");
+        var pagination = PaginationInfo.Create(2, 15);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert
+        LogAssert("Verifying comma separator");
+        result.ShouldBe("Page: 2, PageSize: 15, Index: 1, Offset: 15");
+    }
+
+    [Fact]
+    public void ToString_SortCollectionFormat_MustHaveCorrectSeparator()
+    {
+        // Arrange - mata mutante de string na linha 290 (string.Join ", ")
+        LogArrange("Creating pagination with multiple sorts for separator check");
+        var sorts = new[]
+        {
+            SortInfo.Create("Name", SortDirection.Ascending),
+            SortInfo.Create("Age", SortDirection.Descending)
+        };
+        var pagination = PaginationInfo.Create(1, 10, sorts, null);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert - verifica que os sorts estao separados por ", "
+        LogAssert("Verifying SortCollection format with separator");
+        result.ShouldContain("SortCollection: [Name Ascending, Age Descending]");
+    }
+
+    [Fact]
+    public void ToString_FilterCollectionFormat_MustHaveCorrectSeparator()
+    {
+        // Arrange - mata mutante de string na linha 295 (string.Join ", ")
+        LogArrange("Creating pagination with multiple filters for separator check");
+        var filters = new[]
+        {
+            FilterInfo.Create("Status", FilterOperator.Equals, "Active"),
+            FilterInfo.Create("Name", FilterOperator.Contains, "John")
+        };
+        var pagination = PaginationInfo.Create(1, 10, null, filters);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = pagination.ToString();
+
+        // Assert - verifica que os filters estao separados por ", "
+        LogAssert("Verifying FilterCollection format with separator");
+        result.ShouldContain("FilterCollection: [Status Equals Active, Name Contains John]");
+    }
+
+    #endregion
+
+    #region Mutation Killing Tests
+
+    [Fact]
+    public void Index_ShouldBePageMinusOne()
+    {
+        // Arrange
+        LogArrange("Creating pagination");
+        var pagination = PaginationInfo.Create(5, 10);
+
+        // Act & Assert
+        LogAct("Verifying Index calculation");
+        pagination.Index.ShouldBe(4); // 5 - 1
+        pagination.Index.ShouldBe(pagination.Page - 1);
+        LogAssert("Index = Page - 1 verified");
+    }
+
+    [Fact]
+    public void Offset_ShouldBeIndexTimesPageSize()
+    {
+        // Arrange
+        LogArrange("Creating pagination");
+        var pagination = PaginationInfo.Create(3, 15);
+
+        // Act & Assert
+        LogAct("Verifying Offset calculation");
+        pagination.Offset.ShouldBe(30); // (3-1) * 15
+        pagination.Offset.ShouldBe(pagination.Index * pagination.PageSize);
+        LogAssert("Offset = Index * PageSize verified");
+    }
+
+    [Fact]
+    public void IsUnbounded_ShouldBeTrueOnlyForMaxValue()
+    {
+        // Arrange
+        LogArrange("Creating bounded and unbounded paginations");
+        var bounded = PaginationInfo.Create(1, 100);
+        var almostUnbounded = PaginationInfo.CreateFromExistingInfo(1, int.MaxValue - 1, null, null);
+        var unbounded = PaginationInfo.All;
+
+        // Act & Assert
+        LogAct("Verifying IsUnbounded");
+        bounded.IsUnbounded.ShouldBeFalse();
+        almostUnbounded.IsUnbounded.ShouldBeFalse();
+        unbounded.IsUnbounded.ShouldBeTrue();
+        LogAssert("IsUnbounded correctly checks int.MaxValue");
+    }
+
+    [Fact]
+    public void HasSort_ShouldCheckNullAndCount()
+    {
+        // Arrange
+        LogArrange("Creating paginations with various sort states");
+        var noSort = PaginationInfo.Create(1, 10);
+        var emptySort = PaginationInfo.Create(1, 10, Array.Empty<SortInfo>(), null);
+        var withSort = PaginationInfo.Create(1, 10, new[] { SortInfo.Create("Name", SortDirection.Ascending) }, null);
+
+        // Act & Assert
+        LogAct("Verifying HasSort");
+        noSort.HasSort.ShouldBeFalse("Null collection should be false");
+        emptySort.HasSort.ShouldBeFalse("Empty collection should be false");
+        withSort.HasSort.ShouldBeTrue("Non-empty collection should be true");
+        LogAssert("HasSort correctly checks null and count");
+    }
+
+    [Fact]
+    public void HasFilter_ShouldCheckNullAndCount()
+    {
+        // Arrange
+        LogArrange("Creating paginations with various filter states");
+        var noFilter = PaginationInfo.Create(1, 10);
+        var emptyFilter = PaginationInfo.Create(1, 10, null, Array.Empty<FilterInfo>());
+        var withFilter = PaginationInfo.Create(1, 10, null, new[] { FilterInfo.Create("Status", FilterOperator.Equals, "Active") });
+
+        // Act & Assert
+        LogAct("Verifying HasFilter");
+        noFilter.HasFilter.ShouldBeFalse("Null collection should be false");
+        emptyFilter.HasFilter.ShouldBeFalse("Empty collection should be false");
+        withFilter.HasFilter.ShouldBeTrue("Non-empty collection should be true");
+        LogAssert("HasFilter correctly checks null and count");
+    }
+
+    [Fact]
+    public void Equals_AllFieldsMustMatch()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos for comprehensive equality check");
+        var reference = PaginationInfo.Create(2, 20);
+        var diffPageOnly = PaginationInfo.Create(3, 20);
+        var diffPageSizeOnly = PaginationInfo.Create(2, 30);
+
+        // Act & Assert
+        LogAct("Verifying each field affects equality");
+        reference.Equals(diffPageOnly).ShouldBeFalse("Page must affect equality");
+        reference.Equals(diffPageSizeOnly).ShouldBeFalse("PageSize must affect equality");
+        LogAssert("All equality conditions verified");
+    }
+
+    [Fact]
+    public void InequalityOperator_ShouldNegateEquals()
+    {
+        // Arrange
+        LogArrange("Creating PaginationInfos for inequality check");
+        var pagination1 = PaginationInfo.Create(1, 10);
+        var pagination2Same = PaginationInfo.Create(1, 10);
+        var pagination3Diff = PaginationInfo.Create(2, 20);
+
+        // Act & Assert
+        LogAct("Verifying != negates ==");
+        (pagination1 == pagination2Same).ShouldBeTrue();
+        (pagination1 != pagination2Same).ShouldBeFalse();
+        (pagination1 == pagination3Diff).ShouldBeFalse();
+        (pagination1 != pagination3Diff).ShouldBeTrue();
+        LogAssert("Inequality operator correctly negates equality");
+    }
+
+    #endregion
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Sortings/Enums/SortDirectionTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Sortings/Enums/SortDirectionTests.cs
@@ -1,0 +1,94 @@
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using SortDirection = Bedrock.BuildingBlocks.Core.Sortings.Enums.SortDirection;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Sortings.Enums;
+
+public class SortDirectionTests : TestBase
+{
+    public SortDirectionTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void Ascending_ShouldHaveValue1()
+    {
+        // Arrange
+        LogArrange("Getting Ascending value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)SortDirection.Ascending;
+
+        // Assert
+        LogAssert("Verifying value is 1");
+        value.ShouldBe(1);
+        LogInfo("Ascending = {0}", value);
+    }
+
+    [Fact]
+    public void Descending_ShouldHaveValue2()
+    {
+        // Arrange
+        LogArrange("Getting Descending value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)SortDirection.Descending;
+
+        // Assert
+        LogAssert("Verifying value is 2");
+        value.ShouldBe(2);
+        LogInfo("Descending = {0}", value);
+    }
+
+    [Fact]
+    public void SortDirection_ShouldHaveExactlyTwoValues()
+    {
+        // Arrange
+        LogArrange("Getting all enum values");
+
+        // Act
+        LogAct("Counting enum values");
+        var values = Enum.GetValues<SortDirection>();
+
+        // Assert
+        LogAssert("Verifying count is 2");
+        values.Length.ShouldBe(2);
+        LogInfo("SortDirection has {0} values", values.Length);
+    }
+
+    [Fact]
+    public void SortDirection_ToString_ShouldReturnName()
+    {
+        // Arrange
+        LogArrange("Creating SortDirection values");
+
+        // Act & Assert
+        LogAct("Checking ToString");
+        SortDirection.Ascending.ToString().ShouldBe("Ascending");
+        SortDirection.Descending.ToString().ShouldBe("Descending");
+        LogAssert("ToString returns correct names");
+    }
+
+    [Theory]
+    [InlineData(SortDirection.Ascending, "Ascending")]
+    [InlineData(SortDirection.Descending, "Descending")]
+    public void SortDirection_Parse_ShouldWork(SortDirection expected, string name)
+    {
+        // Arrange
+        LogArrange("Parsing enum");
+        LogInfo("Name: {0}", name);
+
+        // Act
+        LogAct("Parsing enum");
+        var parsed = Enum.Parse<SortDirection>(name);
+
+        // Assert
+        LogAssert("Verifying parsed value");
+        parsed.ShouldBe(expected);
+        LogInfo("Parsed {0} = {1}", name, parsed);
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Sortings/SortInfoTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Sortings/SortInfoTests.cs
@@ -1,0 +1,419 @@
+using Bedrock.BuildingBlocks.Core.Sortings;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using SortDirection = Bedrock.BuildingBlocks.Core.Sortings.Enums.SortDirection;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Sortings;
+
+public class SortInfoTests : TestBase
+{
+    public SortInfoTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    #region Create Tests
+
+    [Fact]
+    public void Create_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up sort info components");
+        var field = "LastName";
+        var direction = SortDirection.Ascending;
+
+        // Act
+        LogAct("Creating SortInfo");
+        var sort = SortInfo.Create(field, direction);
+
+        // Assert
+        LogAssert("Verifying all properties are set");
+        sort.Field.ShouldBe(field);
+        sort.Direction.ShouldBe(direction);
+        LogInfo("SortInfo created: {0}", sort);
+    }
+
+    [Fact]
+    public void Create_WithDescending_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Setting up descending sort");
+        var field = "CreatedAt";
+        var direction = SortDirection.Descending;
+
+        // Act
+        LogAct("Creating SortInfo with Descending");
+        var sort = SortInfo.Create(field, direction);
+
+        // Assert
+        LogAssert("Verifying descending sort");
+        sort.Field.ShouldBe("CreatedAt");
+        sort.Direction.ShouldBe(SortDirection.Descending);
+        LogInfo("Descending SortInfo: {0}", sort);
+    }
+
+    [Fact]
+    public void Create_WithNullField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing null field");
+
+        // Act & Assert
+        LogAct("Creating SortInfo with null field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            SortInfo.Create(null!, SortDirection.Ascending));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    [Fact]
+    public void Create_WithEmptyField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing empty field");
+
+        // Act & Assert
+        LogAct("Creating SortInfo with empty field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            SortInfo.Create("", SortDirection.Ascending));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceField_ShouldThrowArgumentException()
+    {
+        // Arrange
+        LogArrange("Preparing whitespace field");
+
+        // Act & Assert
+        LogAct("Creating SortInfo with whitespace field");
+        var exception = Should.Throw<ArgumentException>(() =>
+            SortInfo.Create("   ", SortDirection.Ascending));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("field");
+        LogInfo("Exception thrown: {0}", exception.Message);
+    }
+
+    #endregion
+
+    #region CreateFromExistingInfo Tests
+
+    [Fact]
+    public void CreateFromExistingInfo_ShouldSetAllProperties()
+    {
+        // Arrange
+        LogArrange("Setting up existing info");
+        var field = "Email";
+        var direction = SortDirection.Descending;
+
+        // Act
+        LogAct("Creating from existing info");
+        var sort = SortInfo.CreateFromExistingInfo(field, direction);
+
+        // Assert
+        LogAssert("Verifying properties");
+        sort.Field.ShouldBe(field);
+        sort.Direction.ShouldBe(direction);
+        LogInfo("SortInfo from existing: {0}", sort);
+    }
+
+    [Fact]
+    public void CreateFromExistingInfo_WithEmptyField_ShouldNotThrow()
+    {
+        // Arrange
+        LogArrange("Preparing empty field for existing info");
+
+        // Act
+        LogAct("Creating from existing info with empty field");
+        var sort = SortInfo.CreateFromExistingInfo("", SortDirection.Ascending);
+
+        // Assert
+        LogAssert("Verifying no exception and empty field");
+        sort.Field.ShouldBe("");
+        LogInfo("Empty field accepted in CreateFromExistingInfo");
+    }
+
+    #endregion
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equals_WithSameValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two SortInfos with same values");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Name", SortDirection.Ascending);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = sort1.Equals(sort2);
+
+        // Assert
+        LogAssert("Verifying equality");
+        areEqual.ShouldBeTrue();
+        LogInfo("SortInfos are equal");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentField_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating SortInfos with different fields");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Email", SortDirection.Ascending);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = sort1.Equals(sort2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+        LogInfo("SortInfos with different fields are not equal");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentDirection_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating SortInfos with different directions");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Name", SortDirection.Descending);
+
+        // Act
+        LogAct("Comparing for equality");
+        var areEqual = sort1.Equals(sort2);
+
+        // Assert
+        LogAssert("Verifying inequality");
+        areEqual.ShouldBeFalse();
+        LogInfo("SortInfos with different directions are not equal");
+    }
+
+    [Fact]
+    public void Equals_WithObjectParameter_ShouldWork()
+    {
+        // Arrange
+        LogArrange("Creating SortInfo and objects for equality test");
+        var sort = SortInfo.Create("Name", SortDirection.Ascending);
+        object objSame = SortInfo.Create("Name", SortDirection.Ascending);
+        object objDifferent = SortInfo.Create("Email", SortDirection.Ascending);
+        object? objNull = null;
+        object objWrongType = "not a sort";
+
+        // Act & Assert
+        LogAct("Testing Equals with various object types");
+        sort.Equals(objSame).ShouldBeTrue();
+        sort.Equals(objDifferent).ShouldBeFalse();
+        sort.Equals(objNull).ShouldBeFalse();
+        sort.Equals(objWrongType).ShouldBeFalse();
+        LogAssert("Object equality tests passed");
+    }
+
+    [Fact]
+    public void EqualityOperator_WithSameValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two SortInfos with same values");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Name", SortDirection.Ascending);
+
+        // Act & Assert
+        LogAct("Testing equality operator");
+        (sort1 == sort2).ShouldBeTrue();
+        LogAssert("Equality operator works correctly");
+    }
+
+    [Fact]
+    public void EqualityOperator_WithDifferentValues_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating two different SortInfos");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Email", SortDirection.Descending);
+
+        // Act & Assert
+        LogAct("Testing equality operator");
+        (sort1 == sort2).ShouldBeFalse();
+        LogAssert("Equality operator correctly returns false");
+    }
+
+    [Fact]
+    public void InequalityOperator_WithSameValues_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating two SortInfos with same values");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Name", SortDirection.Ascending);
+
+        // Act & Assert
+        LogAct("Testing inequality operator");
+        (sort1 != sort2).ShouldBeFalse();
+        LogAssert("Inequality operator correctly returns false");
+    }
+
+    [Fact]
+    public void InequalityOperator_WithDifferentValues_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating two different SortInfos");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Email", SortDirection.Descending);
+
+        // Act & Assert
+        LogAct("Testing inequality operator");
+        (sort1 != sort2).ShouldBeTrue();
+        LogAssert("Inequality operator works correctly");
+    }
+
+    #endregion
+
+    #region GetHashCode Tests
+
+    [Fact]
+    public void GetHashCode_SameValues_ShouldReturnSameHash()
+    {
+        // Arrange
+        LogArrange("Creating two SortInfos with same values");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Name", SortDirection.Ascending);
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = sort1.GetHashCode();
+        var hash2 = sort2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are equal");
+        hash1.ShouldBe(hash2);
+        LogInfo("Hash codes: {0} == {1}", hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentValues_ShouldReturnDifferentHash()
+    {
+        // Arrange
+        LogArrange("Creating two different SortInfos");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2 = SortInfo.Create("Email", SortDirection.Descending);
+
+        // Act
+        LogAct("Getting hash codes");
+        var hash1 = sort1.GetHashCode();
+        var hash2 = sort2.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying hash codes are different");
+        hash1.ShouldNotBe(hash2);
+        LogInfo("Hash codes: {0} != {1}", hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldCombineAllFields()
+    {
+        // Arrange
+        LogArrange("Creating SortInfos differing in single fields");
+        var baseSort = SortInfo.Create("Name", SortDirection.Ascending);
+        var diffField = SortInfo.Create("Email", SortDirection.Ascending);
+        var diffDirection = SortInfo.Create("Name", SortDirection.Descending);
+
+        // Act
+        LogAct("Getting hash codes");
+        var baseHash = baseSort.GetHashCode();
+        var fieldHash = diffField.GetHashCode();
+        var directionHash = diffDirection.GetHashCode();
+
+        // Assert
+        LogAssert("Verifying all fields contribute to hash");
+        baseHash.ShouldNotBe(fieldHash, "Field should affect hash");
+        baseHash.ShouldNotBe(directionHash, "Direction should affect hash");
+        LogInfo("All fields contribute to hash code");
+    }
+
+    #endregion
+
+    #region ToString Tests
+
+    [Fact]
+    public void ToString_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating SortInfo");
+        var sort = SortInfo.Create("LastName", SortDirection.Ascending);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = sort.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("LastName Ascending");
+        LogInfo("ToString: {0}", result);
+    }
+
+    [Fact]
+    public void ToString_WithDescending_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        LogArrange("Creating descending SortInfo");
+        var sort = SortInfo.Create("CreatedAt", SortDirection.Descending);
+
+        // Act
+        LogAct("Calling ToString");
+        var result = sort.ToString();
+
+        // Assert
+        LogAssert("Verifying format");
+        result.ShouldBe("CreatedAt Descending");
+        LogInfo("ToString: {0}", result);
+    }
+
+    #endregion
+
+    #region Mutation Killing Tests
+
+    [Fact]
+    public void Equals_AllFieldsMustMatch()
+    {
+        // Arrange
+        LogArrange("Creating SortInfos for comprehensive equality check");
+        var reference = SortInfo.Create("Name", SortDirection.Ascending);
+
+        var diffFieldOnly = SortInfo.Create("Email", SortDirection.Ascending);
+        var diffDirectionOnly = SortInfo.Create("Name", SortDirection.Descending);
+
+        // Act & Assert
+        LogAct("Verifying each field affects equality");
+        reference.Equals(diffFieldOnly).ShouldBeFalse("Field must affect equality");
+        reference.Equals(diffDirectionOnly).ShouldBeFalse("Direction must affect equality");
+        LogAssert("All equality conditions verified");
+    }
+
+    [Fact]
+    public void InequalityOperator_ShouldNegateEquals()
+    {
+        // Arrange
+        LogArrange("Creating SortInfos for inequality check");
+        var sort1 = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort2Same = SortInfo.Create("Name", SortDirection.Ascending);
+        var sort3Diff = SortInfo.Create("Email", SortDirection.Descending);
+
+        // Act & Assert
+        LogAct("Verifying != negates ==");
+        (sort1 == sort2Same).ShouldBeTrue();
+        (sort1 != sort2Same).ShouldBeFalse();
+        (sort1 == sort3Diff).ShouldBeFalse();
+        (sort1 != sort3Diff).ShouldBeTrue();
+        LogAssert("Inequality operator correctly negates equality");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `SortDirection` enum and `SortInfo` readonly struct for query sorting
- Add `FilterOperator` enum (12 operators) and `FilterInfo` readonly struct for query filtering
- Add `PaginationInfo` readonly struct with Page, PageSize, Index, Offset and optional sort/filter collections

## Features
- All structures are `readonly struct` implementing `IEquatable<T>`
- Factory methods with validation (`Create`) and without validation (`CreateFromExistingInfo`)
- FilterInfo supports single value, range (Between), and list (In/NotIn) operations
- PaginationInfo includes `All` property for unbounded queries

## Test plan
- [x] Unit tests for SortDirection enum
- [x] Unit tests for SortInfo struct (Create, equality, hash, toString)
- [x] Unit tests for FilterOperator enum (all 12 values)
- [x] Unit tests for FilterInfo struct (Create, CreateBetween, CreateIn, CreateNotIn, equality)
- [x] Unit tests for PaginationInfo struct (Create, All, With methods, equality)
- [x] Mutation tests at 100%

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)