### PR TITLE
Implementar métodos de extensão (String e Type)

### DIFF
--- a/src/BuildingBlocks/Core/Extensions/StringExtensions.cs
+++ b/src/BuildingBlocks/Core/Extensions/StringExtensions.cs
@@ -1,0 +1,145 @@
+using System.Globalization;
+using System.Text;
+
+namespace Bedrock.BuildingBlocks.Core.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="string"/>.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// The separator character used in kebab-case strings.
+    /// </summary>
+    public const char KebabCaseSeparator = '-';
+
+    /// <summary>
+    /// The separator character used in snake_case strings.
+    /// </summary>
+    public const char SnakeCaseSeparator = '_';
+
+    /// <summary>
+    /// Converts a string to kebab-case (e.g., "HelloWorld" becomes "hello-world").
+    /// </summary>
+    /// <param name="input">The input string to convert.</param>
+    /// <returns>The kebab-case representation of the input string, or null if input is null.</returns>
+    public static string? ToKebabCase(this string? input)
+    {
+        if (input is null)
+        {
+            return null;
+        }
+
+        if (input.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        bool lastCharWasLowerCase = false;
+        // Stryker disable once Boolean : Mutante equivalente - valor inicial sobrescrito antes do primeiro uso efetivo
+        bool lastCharWasSeparator = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char character = input[i];
+
+            if (!char.IsLetterOrDigit(character))
+            {
+                if (CanAppendKebabSeparator(builder, lastCharWasSeparator, character))
+                {
+                    builder.Append(KebabCaseSeparator);
+                    lastCharWasSeparator = true;
+                }
+            }
+            else if (char.IsUpper(character))
+            {
+                if (lastCharWasLowerCase && !lastCharWasSeparator)
+                {
+                    builder.Append(KebabCaseSeparator);
+                }
+
+                builder.Append(char.ToLower(character, CultureInfo.InvariantCulture));
+                lastCharWasLowerCase = false;
+                lastCharWasSeparator = false;
+            }
+            else
+            {
+                builder.Append(character);
+                lastCharWasLowerCase = true;
+                lastCharWasSeparator = false;
+            }
+        }
+
+        string result = builder.ToString();
+
+        if (result.Length > 0 && result[^1] == KebabCaseSeparator)
+        {
+            return result[..^1];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Converts a string to snake_case (e.g., "HelloWorld" becomes "hello_world").
+    /// </summary>
+    /// <param name="value">The input string to convert.</param>
+    /// <returns>The snake_case representation of the input string.</returns>
+    public static string ToSnakeCase(this string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder();
+        builder.Append(char.ToLowerInvariant(value[0]));
+
+        for (int i = 1; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (char.IsUpper(c))
+            {
+                builder.Append(SnakeCaseSeparator);
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Removes all non-alphanumeric characters from a string.
+    /// </summary>
+    /// <param name="value">The input string to filter.</param>
+    /// <returns>A string containing only letters and digits from the input.</returns>
+    public static string OnlyLettersAndDigits(this string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder();
+
+        foreach (char c in value)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool CanAppendKebabSeparator(StringBuilder builder, bool lastCharWasSeparator, char character)
+    {
+        return builder.Length > 0 && !lastCharWasSeparator && character == KebabCaseSeparator;
+    }
+}

--- a/src/BuildingBlocks/Core/Extensions/TypeExtensions.cs
+++ b/src/BuildingBlocks/Core/Extensions/TypeExtensions.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace Bedrock.BuildingBlocks.Core.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="Type"/>.
+/// </summary>
+public static class TypeExtensions
+{
+    /// <summary>
+    /// Gets all public constant string values defined in a type.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns>An array of string values from all public constant fields of type string.</returns>
+    public static string[] GetAllPublicConstantStringValues(this Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        return [.. type
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)];
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Extensions/StringExtensionsTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,584 @@
+using Bedrock.BuildingBlocks.Core.Extensions;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Extensions;
+
+public class StringExtensionsTests : TestBase
+{
+    public StringExtensionsTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    #region Constants Tests
+
+    [Fact]
+    public void KebabCaseSeparator_ShouldBeHyphen()
+    {
+        // Arrange
+        LogArrange("Getting KebabCaseSeparator constant");
+
+        // Act
+        LogAct("Reading constant value");
+        var separator = StringExtensions.KebabCaseSeparator;
+
+        // Assert
+        LogAssert("Verifying value is hyphen");
+        separator.ShouldBe('-');
+    }
+
+    [Fact]
+    public void SnakeCaseSeparator_ShouldBeUnderscore()
+    {
+        // Arrange
+        LogArrange("Getting SnakeCaseSeparator constant");
+
+        // Act
+        LogAct("Reading constant value");
+        var separator = StringExtensions.SnakeCaseSeparator;
+
+        // Assert
+        LogAssert("Verifying value is underscore");
+        separator.ShouldBe('_');
+    }
+
+    #endregion
+
+    #region ToKebabCase Tests
+
+    [Fact]
+    public void ToKebabCase_Null_ShouldReturnNull()
+    {
+        // Arrange
+        LogArrange("Preparing null input");
+        string? input = null;
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result is null");
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToKebabCase_EmptyString_ShouldReturnEmpty()
+    {
+        // Arrange
+        LogArrange("Preparing empty string");
+        string input = string.Empty;
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result is empty");
+        result.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("HelloWorld", "hello-world")]
+    [InlineData("helloWorld", "hello-world")]
+    [InlineData("Hello", "hello")]
+    [InlineData("hello", "hello")]
+    [InlineData("HELLO", "hello")]
+    [InlineData("ABCdef", "abcdef")]
+    [InlineData("XMLParser", "xmlparser")]
+    [InlineData("myXMLParser", "my-xmlparser")]
+    public void ToKebabCase_PascalOrCamelCase_ShouldConvertCorrectly(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Theory]
+    [InlineData("Hello-World", "hello-world")]
+    [InlineData("hello-world", "hello-world")]
+    [InlineData("Hello--World", "hello-world")]
+    [InlineData("-Hello-World-", "hello-world")]
+    public void ToKebabCase_WithExistingHyphens_ShouldHandleCorrectly(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input with hyphens");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Theory]
+    [InlineData("Hello World", "hello-world")]
+    [InlineData("Hello_World", "hello-world")]
+    [InlineData("Hello.World", "hello-world")]
+    public void ToKebabCase_WithOtherSeparators_ShouldRemoveAndAddSeparatorOnCaseChange(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input with other separators");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Theory]
+    [InlineData("Test123", "test123")]
+    [InlineData("Test123Value", "test123-value")]
+    [InlineData("123Test", "123-test")]
+    public void ToKebabCase_WithDigits_ShouldPreserveDigits(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input with digits");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Fact]
+    public void ToKebabCase_SingleUpperCase_ShouldReturnLowerCase()
+    {
+        // Arrange
+        LogArrange("Preparing single uppercase");
+        string input = "A";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe("a");
+    }
+
+    [Fact]
+    public void ToKebabCase_SingleLowerCase_ShouldReturnSame()
+    {
+        // Arrange
+        LogArrange("Preparing single lowercase");
+        string input = "a";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe("a");
+    }
+
+    [Fact]
+    public void ToKebabCase_TrailingHyphen_ShouldRemoveIt()
+    {
+        // Arrange
+        LogArrange("Preparing input with trailing hyphen");
+        string input = "Hello-";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying trailing hyphen removed");
+        result.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void ToKebabCase_LeadingHyphen_ShouldRemoveIt()
+    {
+        // Arrange
+        LogArrange("Preparing input with leading hyphen");
+        string input = "-Hello";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying leading hyphen removed");
+        result.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void ToKebabCase_OnlyHyphens_ShouldReturnEmpty()
+    {
+        // Arrange
+        LogArrange("Preparing input with only hyphens");
+        string input = "---";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying result is empty");
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void ToKebabCase_ConsecutiveUppercase_ShouldNotSeparate()
+    {
+        // Arrange
+        LogArrange("Preparing consecutive uppercase");
+        string input = "ABC";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying no separation between uppercase");
+        result.ShouldBe("abc");
+    }
+
+    [Fact]
+    public void ToKebabCase_MixedWithSpecialChars_ShouldIgnoreNonHyphen()
+    {
+        // Arrange
+        LogArrange("Preparing input with special characters");
+        string input = "Hello!World";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying special chars removed and case transition handled");
+        result.ShouldBe("hello-world");
+    }
+
+    [Fact]
+    public void ToKebabCase_DigitAfterLowercase_ShouldNotAddSeparator()
+    {
+        // Arrange
+        LogArrange("Preparing digit after lowercase");
+        string input = "test1";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying no separator before digit");
+        result.ShouldBe("test1");
+    }
+
+    [Fact]
+    public void ToKebabCase_LowercaseHyphenUppercase_ShouldKeepHyphen()
+    {
+        // Arrange - kills mutant on line 40 (lastCharWasSeparator = false initialization)
+        // If lastCharWasSeparator starts as true, the first hyphen would be ignored
+        LogArrange("Preparing lowercase-hyphen-uppercase sequence");
+        string input = "a-B";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying hyphen is preserved");
+        result.ShouldBe("a-b");
+    }
+
+    [Fact]
+    public void ToKebabCase_UppercaseHyphenLowercase_ShouldKeepHyphen()
+    {
+        // Arrange - kills mutant on line 63 (lastCharWasSeparator = false after uppercase)
+        // If lastCharWasSeparator becomes true after uppercase, subsequent hyphen would be ignored
+        LogArrange("Preparing uppercase-hyphen-lowercase sequence");
+        string input = "A-b";
+
+        // Act
+        LogAct("Calling ToKebabCase");
+        var result = input.ToKebabCase();
+
+        // Assert
+        LogAssert("Verifying hyphen after uppercase is preserved");
+        result.ShouldBe("a-b");
+    }
+
+    #endregion
+
+    #region ToSnakeCase Tests
+
+    [Fact]
+    public void ToSnakeCase_Null_ShouldReturnNull()
+    {
+        // Arrange
+        LogArrange("Preparing null input");
+        string input = null!;
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result is null");
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToSnakeCase_EmptyString_ShouldReturnEmpty()
+    {
+        // Arrange
+        LogArrange("Preparing empty string");
+        string input = string.Empty;
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result is empty");
+        result.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("HelloWorld", "hello_world")]
+    [InlineData("helloWorld", "hello_world")]
+    [InlineData("Hello", "hello")]
+    [InlineData("hello", "hello")]
+    [InlineData("HELLO", "h_e_l_l_o")]
+    [InlineData("ABCdef", "a_b_cdef")]
+    [InlineData("XMLParser", "x_m_l_parser")]
+    public void ToSnakeCase_PascalOrCamelCase_ShouldConvertCorrectly(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Theory]
+    [InlineData("Test123", "test123")]
+    [InlineData("Test123Value", "test123_value")]
+    [InlineData("123Test", "123_test")]
+    public void ToSnakeCase_WithDigits_ShouldPreserveDigits(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input with digits");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Fact]
+    public void ToSnakeCase_SingleUpperCase_ShouldReturnLowerCase()
+    {
+        // Arrange
+        LogArrange("Preparing single uppercase");
+        string input = "A";
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe("a");
+    }
+
+    [Fact]
+    public void ToSnakeCase_SingleLowerCase_ShouldReturnSame()
+    {
+        // Arrange
+        LogArrange("Preparing single lowercase");
+        string input = "a";
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe("a");
+    }
+
+    [Fact]
+    public void ToSnakeCase_WithSpecialChars_ShouldPreserve()
+    {
+        // Arrange
+        LogArrange("Preparing input with special characters");
+        string input = "Hello_World";
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying special chars preserved");
+        result.ShouldBe("hello__world");
+    }
+
+    [Fact]
+    public void ToSnakeCase_ConsecutiveUppercase_ShouldSeparateEach()
+    {
+        // Arrange
+        LogArrange("Preparing consecutive uppercase");
+        string input = "ABC";
+
+        // Act
+        LogAct("Calling ToSnakeCase");
+        var result = input.ToSnakeCase();
+
+        // Assert
+        LogAssert("Verifying each letter separated");
+        result.ShouldBe("a_b_c");
+    }
+
+    #endregion
+
+    #region OnlyLettersAndDigits Tests
+
+    [Fact]
+    public void OnlyLettersAndDigits_Null_ShouldReturnNull()
+    {
+        // Arrange
+        LogArrange("Preparing null input");
+        string input = null!;
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying result is null");
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void OnlyLettersAndDigits_EmptyString_ShouldReturnEmpty()
+    {
+        // Arrange
+        LogArrange("Preparing empty string");
+        string input = string.Empty;
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying result is empty");
+        result.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("Hello123", "Hello123")]
+    [InlineData("Hello World", "HelloWorld")]
+    [InlineData("Hello-World", "HelloWorld")]
+    [InlineData("Hello_World", "HelloWorld")]
+    [InlineData("Hello.World!", "HelloWorld")]
+    [InlineData("@#$%^&*()", "")]
+    [InlineData("Test!@#123", "Test123")]
+    public void OnlyLettersAndDigits_ShouldFilterCorrectly(string input, string expected)
+    {
+        // Arrange
+        LogArrange("Preparing input");
+        LogInfo("Input: {0}", input);
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying result");
+        result.ShouldBe(expected);
+        LogInfo("Result: {0}", result);
+    }
+
+    [Fact]
+    public void OnlyLettersAndDigits_OnlyLetters_ShouldReturnSame()
+    {
+        // Arrange
+        LogArrange("Preparing only letters");
+        string input = "HelloWorld";
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying result unchanged");
+        result.ShouldBe("HelloWorld");
+    }
+
+    [Fact]
+    public void OnlyLettersAndDigits_OnlyDigits_ShouldReturnSame()
+    {
+        // Arrange
+        LogArrange("Preparing only digits");
+        string input = "12345";
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying result unchanged");
+        result.ShouldBe("12345");
+    }
+
+    [Fact]
+    public void OnlyLettersAndDigits_MixedWithUnicode_ShouldPreserveLetters()
+    {
+        // Arrange
+        LogArrange("Preparing input with unicode");
+        string input = "Héllo123";
+
+        // Act
+        LogAct("Calling OnlyLettersAndDigits");
+        var result = input.OnlyLettersAndDigits();
+
+        // Assert
+        LogAssert("Verifying unicode letters preserved");
+        result.ShouldBe("Héllo123");
+    }
+
+    #endregion
+}

--- a/tests/UnitTests/BuildingBlocks/Core/Extensions/TypeExtensionsTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Core/Extensions/TypeExtensionsTests.cs
@@ -1,0 +1,195 @@
+using Bedrock.BuildingBlocks.Core.Extensions;
+using Bedrock.BuildingBlocks.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Core.Extensions;
+
+public class TypeExtensionsTests : TestBase
+{
+    public TypeExtensionsTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    #region Test Helper Classes
+
+    private static class TestClassWithConstants
+    {
+        public const string Constant1 = "Value1";
+        public const string Constant2 = "Value2";
+        public const string Constant3 = "Value3";
+    }
+
+    private static class TestClassWithMixedMembers
+    {
+        public const string StringConstant = "StringValue";
+        public const int IntConstant = 42;
+        public static readonly string ReadOnlyField = "ReadOnly";
+        public static string StaticField = "Static";
+        private const string PrivateConstant = "Private";
+    }
+
+    private static class TestClassWithNoConstants
+    {
+        public static string Field = "NotConstant";
+        public static readonly string ReadOnly = "ReadOnly";
+    }
+
+    private static class EmptyTestClass
+    {
+    }
+
+    private class DerivedClassWithConstants : BaseClassWithConstants
+    {
+        public const string DerivedConstant = "DerivedValue";
+    }
+
+    private class BaseClassWithConstants
+    {
+        public const string BaseConstant = "BaseValue";
+    }
+
+    #endregion
+
+    #region GetAllPublicConstantStringValues Tests
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_NullType_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        LogArrange("Preparing null type");
+        Type type = null!;
+
+        // Act & Assert
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var exception = Should.Throw<ArgumentNullException>(() => type.GetAllPublicConstantStringValues());
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("type");
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_TypeWithStringConstants_ShouldReturnAllValues()
+    {
+        // Arrange
+        LogArrange("Preparing type with string constants");
+        var type = typeof(TestClassWithConstants);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying all constants returned");
+        result.Length.ShouldBe(3);
+        result.ShouldContain("Value1");
+        result.ShouldContain("Value2");
+        result.ShouldContain("Value3");
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_TypeWithMixedMembers_ShouldReturnOnlyPublicStringConstants()
+    {
+        // Arrange
+        LogArrange("Preparing type with mixed members");
+        var type = typeof(TestClassWithMixedMembers);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying only public string constants returned");
+        result.Length.ShouldBe(1);
+        result.ShouldContain("StringValue");
+        result.ShouldNotContain("ReadOnly");
+        result.ShouldNotContain("Static");
+        result.ShouldNotContain("Private");
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_TypeWithNoConstants_ShouldReturnEmptyArray()
+    {
+        // Arrange
+        LogArrange("Preparing type with no constants");
+        var type = typeof(TestClassWithNoConstants);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying empty array returned");
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_EmptyType_ShouldReturnEmptyArray()
+    {
+        // Arrange
+        LogArrange("Preparing empty type");
+        var type = typeof(EmptyTestClass);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying empty array returned");
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_DerivedClass_ShouldIncludeBaseConstants()
+    {
+        // Arrange
+        LogArrange("Preparing derived class");
+        var type = typeof(DerivedClassWithConstants);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying both base and derived constants returned");
+        result.Length.ShouldBe(2);
+        result.ShouldContain("BaseValue");
+        result.ShouldContain("DerivedValue");
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_BaseClass_ShouldReturnOnlyOwnConstants()
+    {
+        // Arrange
+        LogArrange("Preparing base class");
+        var type = typeof(BaseClassWithConstants);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying only base constant returned");
+        result.Length.ShouldBe(1);
+        result.ShouldContain("BaseValue");
+    }
+
+    [Fact]
+    public void GetAllPublicConstantStringValues_BuiltInType_ShouldReturnEmptyArray()
+    {
+        // Arrange
+        LogArrange("Preparing built-in type");
+        var type = typeof(int);
+
+        // Act
+        LogAct("Calling GetAllPublicConstantStringValues");
+        var result = type.GetAllPublicConstantStringValues();
+
+        // Assert
+        LogAssert("Verifying empty array returned");
+        result.ShouldBeEmpty();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Adiciona `StringExtensions` com métodos para conversão de case e filtragem
  - `ToKebabCase()` - Converte para kebab-case (ex: `HelloWorld` → `hello-world`)
  - `ToSnakeCase()` - Converte para snake_case (ex: `HelloWorld` → `hello_world`)
  - `OnlyLettersAndDigits()` - Remove caracteres não alfanuméricos
- Adiciona `TypeExtensions` com método de reflexão
  - `GetAllPublicConstantStringValues()` - Obtém valores de constantes públicas string

## Test plan

- [x] Testes unitários para todos os métodos
- [x] Cobertura de código 100%
- [x] Mutation score 100%
- [x] Pipeline local passa

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)