### PR TITLE
feat(observability): add ILogger extension methods for distributed tracing

### DIFF
--- a/Bedrock.sln
+++ b/Bedrock.sln
@@ -81,6 +81,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Serialization.Parquet", "Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.UnitTests.BuildingBlocks.Serialization.Parquet", "tests\UnitTests\BuildingBlocks\Serialization.Parquet\Bedrock.UnitTests.BuildingBlocks.Serialization.Parquet.csproj", "{6C7D8B22-1B4E-4C59-B0D6-DB0B3C547516}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Observability", "Observability", "{1E9763A7-D200-66D3-7DE0-D604C99B8A0F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.BuildingBlocks.Observability", "src\BuildingBlocks\Observability\Bedrock.BuildingBlocks.Observability.csproj", "{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Observability", "Observability", "{8AAD5688-74DA-CCBE-4947-823AD4DC4BF5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.UnitTests.BuildingBlocks.Observability", "tests\UnitTests\BuildingBlocks\Observability\Bedrock.UnitTests.BuildingBlocks.Observability.csproj", "{301F7D49-9848-47CA-ABBA-9A737D37E243}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -295,6 +303,30 @@ Global
 		{6C7D8B22-1B4E-4C59-B0D6-DB0B3C547516}.Release|x64.Build.0 = Release|Any CPU
 		{6C7D8B22-1B4E-4C59-B0D6-DB0B3C547516}.Release|x86.ActiveCfg = Release|Any CPU
 		{6C7D8B22-1B4E-4C59-B0D6-DB0B3C547516}.Release|x86.Build.0 = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|x64.Build.0 = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Debug|x86.Build.0 = Debug|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|x64.ActiveCfg = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|x64.Build.0 = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|x86.ActiveCfg = Release|Any CPU
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270}.Release|x86.Build.0 = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|x64.Build.0 = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Debug|x86.Build.0 = Debug|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|Any CPU.Build.0 = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|x64.ActiveCfg = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|x64.Build.0 = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|x86.ActiveCfg = Release|Any CPU
+		{301F7D49-9848-47CA-ABBA-9A737D37E243}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -337,5 +369,9 @@ Global
 		{591D22CF-B530-4260-8237-3BCFABD94BD5} = {53C307F2-7D22-15AB-EFAC-2FB3D20D2B23}
 		{DF825528-3C29-8C79-C5E5-56F0A99AEF59} = {A7B8C9D0-E1F2-3456-0123-567890123456}
 		{6C7D8B22-1B4E-4C59-B0D6-DB0B3C547516} = {DF825528-3C29-8C79-C5E5-56F0A99AEF59}
+		{1E9763A7-D200-66D3-7DE0-D604C99B8A0F} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
+		{5AED8C0A-56B9-49DF-98A8-6C7F2F2EE270} = {1E9763A7-D200-66D3-7DE0-D604C99B8A0F}
+		{8AAD5688-74DA-CCBE-4947-823AD4DC4BF5} = {A7B8C9D0-E1F2-3456-0123-567890123456}
+		{301F7D49-9848-47CA-ABBA-9A737D37E243} = {8AAD5688-74DA-CCBE-4947-823AD4DC4BF5}
 	EndGlobalSection
 EndGlobal

--- a/src/BuildingBlocks/Observability/Bedrock.BuildingBlocks.Observability.csproj
+++ b/src/BuildingBlocks/Observability/Bedrock.BuildingBlocks.Observability.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Assembly Information">
+    <Version>1.0.0-alpha.1</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <InformationalVersion>1.0.0-alpha.1</InformationalVersion>
+    <Company>MarceloCastelo.IO</Company>
+    <Product>Bedrock</Product>
+    <Description>Observability building blocks for Bedrock, providing logging extensions for distributed tracing.</Description>
+    <Copyright>Copyright © 2023-2026 Marcelo Castelo Branco</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Bedrock.BuildingBlocks.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BuildingBlocks/Observability/ExtensionMethods/LoggerExtensionMethods.cs
+++ b/src/BuildingBlocks/Observability/ExtensionMethods/LoggerExtensionMethods.cs
@@ -1,0 +1,164 @@
+using Microsoft.Extensions.Logging;
+
+namespace Bedrock.BuildingBlocks.Observability.ExtensionMethods;
+
+/// <summary>
+/// Extension methods for <see cref="ILogger"/> that provide distributed tracing capabilities
+/// by automatically including <see cref="ExecutionContext"/> information in log scopes.
+/// </summary>
+public static class LoggerExtensionMethods
+{
+    extension(ILogger logger)
+    {
+        /// <summary>
+        /// Logs a trace message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogTraceForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Trace, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs a debug message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogDebugForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Debug, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs an information message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogInformationForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Information, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs a warning message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogWarningForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Warning, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs an error message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogErrorForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Error, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs a critical message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogCriticalForDistributedTracing(
+            ExecutionContext executionContext,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Critical, exception: null, message, args);
+        }
+
+        /// <summary>
+        /// Logs an exception with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        public void LogExceptionForDistributedTracing(
+            ExecutionContext executionContext,
+            Exception exception,
+            string message,
+            params object[] args
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Error, exception, message, args);
+        }
+
+        /// <summary>
+        /// Logs an exception with distributed tracing context from the execution context,
+        /// using the exception message as the log message.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="exception">The exception to log.</param>
+        public void LogExceptionForDistributedTracing(
+            ExecutionContext executionContext,
+            Exception exception
+        )
+        {
+            logger.LogForDistributedTracing(executionContext, LogLevel.Error, exception, message: exception.Message);
+        }
+
+        /// <summary>
+        /// Logs a message with distributed tracing context from the execution context.
+        /// </summary>
+        /// <param name="executionContext">The execution context containing correlation and tracing information.</param>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="exception">The exception to log, if any.</param>
+        /// <param name="message">The message template to log.</param>
+        /// <param name="args">The arguments to format the message template.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="executionContext"/> is null.</exception>
+        public void LogForDistributedTracing(
+            ExecutionContext executionContext,
+            LogLevel logLevel,
+            Exception? exception,
+            string message,
+            params object[] args
+        )
+        {
+            if (!logger.IsEnabled(logLevel))
+                return;
+
+            ArgumentNullException.ThrowIfNull(executionContext);
+
+            using (logger.BeginScope(executionContext.ToDictionary()))
+            {
+#pragma warning disable CA1848, CA2254 // Message template is intentionally dynamic in this wrapper method
+                logger.Log(logLevel, exception, message, args);
+#pragma warning restore CA1848, CA2254
+            }
+        }
+    }
+}

--- a/src/BuildingBlocks/Observability/GlobalUsings.cs
+++ b/src/BuildingBlocks/Observability/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using ExecutionContext = Bedrock.BuildingBlocks.Core.ExecutionContexts.ExecutionContext;

--- a/tests/MutationTests/BuildingBlocks/Observability/stryker-config.json
+++ b/tests/MutationTests/BuildingBlocks/Observability/stryker-config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/src/Stryker.Core/Stryker.Core/stryker-config.schema.json",
+  "stryker-config": {
+    "project": "Bedrock.BuildingBlocks.Observability.csproj",
+    "test-projects": [
+      "../../../UnitTests/BuildingBlocks/Observability/Bedrock.UnitTests.BuildingBlocks.Observability.csproj"
+    ],
+    "reporters": ["html", "progress"],
+    "thresholds": {
+      "high": 100,
+      "low": 100,
+      "break": 100
+    }
+  }
+}

--- a/tests/UnitTests/BuildingBlocks/Observability/Bedrock.UnitTests.BuildingBlocks.Observability.csproj
+++ b/tests/UnitTests/BuildingBlocks/Observability/Bedrock.UnitTests.BuildingBlocks.Observability.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\BuildingBlocks\Testing\Bedrock.BuildingBlocks.Testing.csproj" />
+    <ProjectReference Include="..\..\..\..\src\BuildingBlocks\Observability\Bedrock.BuildingBlocks.Observability.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UnitTests/BuildingBlocks/Observability/ExtensionMethods/LoggerExtensionMethodsTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Observability/ExtensionMethods/LoggerExtensionMethodsTests.cs
@@ -1,0 +1,717 @@
+using Bedrock.BuildingBlocks.Core.ExecutionContexts.Models.Enums;
+using Bedrock.BuildingBlocks.Core.TenantInfos;
+using Bedrock.BuildingBlocks.Observability.ExtensionMethods;
+using Bedrock.BuildingBlocks.Testing;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using ExecutionContext = Bedrock.BuildingBlocks.Core.ExecutionContexts.ExecutionContext;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Observability.ExtensionMethods;
+
+public class LoggerExtensionMethodsTests : TestBase
+{
+    private readonly Mock<ILogger> _loggerMock;
+    private readonly ExecutionContext _executionContext;
+    private readonly List<(LogLevel Level, string Message, object[] Args)> _capturedLogs;
+
+    public LoggerExtensionMethodsTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+        _loggerMock = new Mock<ILogger>();
+        _capturedLogs = [];
+
+        // Setup logger mock to capture log calls
+        _loggerMock
+            .Setup(x => x.IsEnabled(It.IsAny<LogLevel>()))
+            .Returns(true);
+
+        _loggerMock
+            .Setup(x => x.BeginScope(It.IsAny<It.IsAnyType>()))
+            .Returns(Mock.Of<IDisposable>());
+
+        var tenantInfo = TenantInfo.Create(Guid.NewGuid(), "Test Tenant");
+        _executionContext = ExecutionContext.Create(
+            correlationId: Guid.NewGuid(),
+            tenantInfo: tenantInfo,
+            executionUser: "test-user",
+            executionOrigin: "test-origin",
+            businessOperationCode: "TEST_OP",
+            minimumMessageType: MessageType.Trace,
+            timeProvider: TimeProvider.System
+        );
+    }
+
+    #region LogTraceForDistributedTracing Tests
+
+    [Fact]
+    public void LogTraceForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Trace level");
+
+        // Act
+        LogAct("Calling LogTraceForDistributedTracing");
+        _loggerMock.Object.LogTraceForDistributedTracing(_executionContext, "Test message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.Is<Dictionary<string, object?>>(d =>
+                d.ContainsKey("CorrelationId") &&
+                d.ContainsKey("ExecutionUser"))),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Trace,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogTraceForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogTraceForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Trace disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Trace)).Returns(false);
+
+        // Act
+        LogAct("Calling LogTraceForDistributedTracing");
+        _loggerMock.Object.LogTraceForDistributedTracing(_executionContext, "Test message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Trace,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogTraceForDistributedTracing correctly skipped when disabled");
+    }
+
+    [Fact]
+    public void LogTraceForDistributedTracing_WithArgs_ShouldPassArgsToLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Trace level with args");
+
+        // Act
+        LogAct("Calling LogTraceForDistributedTracing with args");
+        _loggerMock.Object.LogTraceForDistributedTracing(_executionContext, "Test {0} message {1}", ["arg1", 42]);
+
+        // Assert
+        LogAssert("Verifying Log was called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Trace,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogTraceForDistributedTracing with args logged successfully");
+    }
+
+    #endregion
+
+    #region LogDebugForDistributedTracing Tests
+
+    [Fact]
+    public void LogDebugForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Debug level");
+
+        // Act
+        LogAct("Calling LogDebugForDistributedTracing");
+        _loggerMock.Object.LogDebugForDistributedTracing(_executionContext, "Debug message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogDebugForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogDebugForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Debug disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(false);
+
+        // Act
+        LogAct("Calling LogDebugForDistributedTracing");
+        _loggerMock.Object.LogDebugForDistributedTracing(_executionContext, "Debug message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogDebugForDistributedTracing correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogInformationForDistributedTracing Tests
+
+    [Fact]
+    public void LogInformationForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Information level");
+
+        // Act
+        LogAct("Calling LogInformationForDistributedTracing");
+        _loggerMock.Object.LogInformationForDistributedTracing(_executionContext, "Info message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogInformationForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogInformationForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Information disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Information)).Returns(false);
+
+        // Act
+        LogAct("Calling LogInformationForDistributedTracing");
+        _loggerMock.Object.LogInformationForDistributedTracing(_executionContext, "Info message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogInformationForDistributedTracing correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogWarningForDistributedTracing Tests
+
+    [Fact]
+    public void LogWarningForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Warning level");
+
+        // Act
+        LogAct("Calling LogWarningForDistributedTracing");
+        _loggerMock.Object.LogWarningForDistributedTracing(_executionContext, "Warning message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogWarningForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogWarningForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Warning disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(false);
+
+        // Act
+        LogAct("Calling LogWarningForDistributedTracing");
+        _loggerMock.Object.LogWarningForDistributedTracing(_executionContext, "Warning message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogWarningForDistributedTracing correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogErrorForDistributedTracing Tests
+
+    [Fact]
+    public void LogErrorForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Error level");
+
+        // Act
+        LogAct("Calling LogErrorForDistributedTracing");
+        _loggerMock.Object.LogErrorForDistributedTracing(_executionContext, "Error message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogErrorForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogErrorForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Error disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(false);
+
+        // Act
+        LogAct("Calling LogErrorForDistributedTracing");
+        _loggerMock.Object.LogErrorForDistributedTracing(_executionContext, "Error message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogErrorForDistributedTracing correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogCriticalForDistributedTracing Tests
+
+    [Fact]
+    public void LogCriticalForDistributedTracing_WhenEnabled_ShouldLogWithScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for Critical level");
+
+        // Act
+        LogAct("Calling LogCriticalForDistributedTracing");
+        _loggerMock.Object.LogCriticalForDistributedTracing(_executionContext, "Critical message");
+
+        // Assert
+        LogAssert("Verifying BeginScope and Log were called");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Critical,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogCriticalForDistributedTracing logged successfully");
+    }
+
+    [Fact]
+    public void LogCriticalForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Critical disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Critical)).Returns(false);
+
+        // Act
+        LogAct("Calling LogCriticalForDistributedTracing");
+        _loggerMock.Object.LogCriticalForDistributedTracing(_executionContext, "Critical message");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Critical,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogCriticalForDistributedTracing correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogExceptionForDistributedTracing Tests
+
+    [Fact]
+    public void LogExceptionForDistributedTracing_WithMessageAndArgs_ShouldLogWithException()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for exception logging");
+        var exception = new InvalidOperationException("Test exception");
+
+        // Act
+        LogAct("Calling LogExceptionForDistributedTracing with message");
+        _loggerMock.Object.LogExceptionForDistributedTracing(_executionContext, exception, "Error occurred: {0}", ["details"]);
+
+        // Assert
+        LogAssert("Verifying Log was called with exception");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogExceptionForDistributedTracing with message logged successfully");
+    }
+
+    [Fact]
+    public void LogExceptionForDistributedTracing_WithExceptionOnly_ShouldLogWithExceptionMessage()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock for exception-only logging");
+        var exception = new InvalidOperationException("Test exception message");
+
+        // Act
+        LogAct("Calling LogExceptionForDistributedTracing with exception only");
+        _loggerMock.Object.LogExceptionForDistributedTracing(_executionContext, exception);
+
+        // Assert
+        LogAssert("Verifying Log was called with exception");
+        _loggerMock.Verify(
+            x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogExceptionForDistributedTracing with exception only logged successfully");
+    }
+
+    [Fact]
+    public void LogExceptionForDistributedTracing_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Error disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(false);
+        var exception = new InvalidOperationException("Test exception");
+
+        // Act
+        LogAct("Calling LogExceptionForDistributedTracing");
+        _loggerMock.Object.LogExceptionForDistributedTracing(_executionContext, exception, "Error");
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogExceptionForDistributedTracing correctly skipped when disabled");
+    }
+
+    [Fact]
+    public void LogExceptionForDistributedTracing_ExceptionOnlyOverload_WhenDisabled_ShouldNotLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with Error disabled");
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(false);
+        var exception = new InvalidOperationException("Test exception");
+
+        // Act
+        LogAct("Calling LogExceptionForDistributedTracing (exception-only overload)");
+        _loggerMock.Object.LogExceptionForDistributedTracing(_executionContext, exception);
+
+        // Assert
+        LogAssert("Verifying Log was not called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+
+        LogInfo("LogExceptionForDistributedTracing (exception-only) correctly skipped when disabled");
+    }
+
+    #endregion
+
+    #region LogForDistributedTracing Tests
+
+    [Fact]
+    public void LogForDistributedTracing_WithNullExecutionContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock");
+
+        // Act & Assert
+        LogAct("Calling LogForDistributedTracing with null context");
+        var exception = Should.Throw<ArgumentNullException>(() =>
+            _loggerMock.Object.LogForDistributedTracing(null!, LogLevel.Information, null, "Message"));
+
+        LogAssert("Verifying exception");
+        exception.ParamName.ShouldBe("executionContext");
+        LogInfo("ArgumentNullException thrown for null ExecutionContext");
+    }
+
+    [Fact]
+    public void LogForDistributedTracing_ScopeContainsExecutionContextData()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock to capture scope");
+        Dictionary<string, object?>? capturedScope = null;
+
+        _loggerMock
+            .Setup(x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()))
+            .Callback<Dictionary<string, object?>>(scope => capturedScope = scope)
+            .Returns(Mock.Of<IDisposable>());
+
+        // Act
+        LogAct("Calling LogForDistributedTracing");
+        _loggerMock.Object.LogForDistributedTracing(
+            _executionContext,
+            LogLevel.Information,
+            null,
+            "Test message");
+
+        // Assert
+        LogAssert("Verifying scope contains execution context data");
+        capturedScope.ShouldNotBeNull();
+        capturedScope.ShouldContainKey("CorrelationId");
+        capturedScope.ShouldContainKey("TenantCode");
+        capturedScope.ShouldContainKey("TenantName");
+        capturedScope.ShouldContainKey("ExecutionUser");
+        capturedScope.ShouldContainKey("ExecutionOrigin");
+        capturedScope.ShouldContainKey("BusinessOperationCode");
+        capturedScope.ShouldContainKey("Timestamp");
+
+        capturedScope["ExecutionUser"].ShouldBe("test-user");
+        capturedScope["ExecutionOrigin"].ShouldBe("test-origin");
+        capturedScope["BusinessOperationCode"].ShouldBe("TEST_OP");
+
+        LogInfo("Scope correctly contains all execution context data");
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogForDistributedTracing_WithDifferentLogLevels_ShouldLogAtCorrectLevel(LogLevel logLevel)
+    {
+        // Arrange
+        LogArrange($"Setting up logger mock for {logLevel} level");
+
+        // Act
+        LogAct($"Calling LogForDistributedTracing with {logLevel}");
+        _loggerMock.Object.LogForDistributedTracing(_executionContext, logLevel, null, "Test message");
+
+        // Assert
+        LogAssert($"Verifying Log was called with {logLevel}");
+        _loggerMock.Verify(
+            x => x.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo($"LogForDistributedTracing logged at {logLevel} level successfully");
+    }
+
+    [Fact]
+    public void LogForDistributedTracing_WithException_ShouldPassExceptionToLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock");
+        var exception = new InvalidOperationException("Test exception");
+
+        // Act
+        LogAct("Calling LogForDistributedTracing with exception");
+        _loggerMock.Object.LogForDistributedTracing(
+            _executionContext,
+            LogLevel.Error,
+            exception,
+            "Error message");
+
+        // Assert
+        LogAssert("Verifying exception was passed to Log");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogForDistributedTracing correctly passed exception to Log");
+    }
+
+    [Fact]
+    public void LogForDistributedTracing_DisposesScope()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock with disposable scope");
+        var disposableMock = new Mock<IDisposable>();
+        _loggerMock
+            .Setup(x => x.BeginScope(It.IsAny<Dictionary<string, object?>>()))
+            .Returns(disposableMock.Object);
+
+        // Act
+        LogAct("Calling LogForDistributedTracing");
+        _loggerMock.Object.LogForDistributedTracing(_executionContext, LogLevel.Information, null, "Message");
+
+        // Assert
+        LogAssert("Verifying scope was disposed");
+        disposableMock.Verify(x => x.Dispose(), Times.Once);
+        LogInfo("Scope was correctly disposed after logging");
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void LogForDistributedTracing_WithEmptyMessage_ShouldLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock");
+
+        // Act
+        LogAct("Calling LogForDistributedTracing with empty message");
+        _loggerMock.Object.LogForDistributedTracing(_executionContext, LogLevel.Information, null, string.Empty);
+
+        // Assert
+        LogAssert("Verifying Log was called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogForDistributedTracing logged empty message successfully");
+    }
+
+    [Fact]
+    public void LogForDistributedTracing_WithEmptyArgs_ShouldLog()
+    {
+        // Arrange
+        LogArrange("Setting up logger mock");
+
+        // Act
+        LogAct("Calling LogForDistributedTracing with empty args");
+        _loggerMock.Object.LogForDistributedTracing(
+            _executionContext,
+            LogLevel.Information,
+            null,
+            "Message with {0}",
+            Array.Empty<object>());
+
+        // Assert
+        LogAssert("Verifying Log was called");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        LogInfo("LogForDistributedTracing logged with empty args successfully");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `Bedrock.BuildingBlocks.Observability` project with ILogger extension methods for distributed tracing
- Extension methods automatically include `ExecutionContext` data (CorrelationId, TenantInfo, ExecutionUser, etc.) in log scopes
- Implement using C# 14 extension member syntax with full XML documentation

## Test plan

- [x] Unit tests created (29 tests passing)
- [x] Code coverage at 100%
- [x] Mutation tests passing (100% mutation score)
- [x] Pipeline passes (`./scripts/pipeline.sh`)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)