### PR TITLE
fix: resolve SonarCloud issues (4 code fixes + 36 false positives)

### DIFF
--- a/src/BuildingBlocks/Core/Extensions/StringExtensions.cs
+++ b/src/BuildingBlocks/Core/Extensions/StringExtensions.cs
@@ -43,37 +43,49 @@ public static class StringExtensions
         for (int i = 0; i < input.Length; i++)
         {
             char character = input[i];
-
-            if (!char.IsLetterOrDigit(character))
-            {
-                if (CanAppendKebabSeparator(builder, lastCharWasSeparator, character))
-                {
-                    builder.Append(KebabCaseSeparator);
-                    lastCharWasSeparator = true;
-                }
-            }
-            else if (char.IsUpper(character))
-            {
-                if (lastCharWasLowerCase && !lastCharWasSeparator)
-                {
-                    builder.Append(KebabCaseSeparator);
-                }
-
-                builder.Append(char.ToLower(character, CultureInfo.InvariantCulture));
-                lastCharWasLowerCase = false;
-                lastCharWasSeparator = false;
-            }
-            else
-            {
-                builder.Append(character);
-                lastCharWasLowerCase = true;
-                lastCharWasSeparator = false;
-            }
+            ProcessKebabCharacter(builder, character, ref lastCharWasLowerCase, ref lastCharWasSeparator);
         }
 
-        string result = builder.ToString();
+        return TrimTrailingSeparator(builder.ToString(), KebabCaseSeparator);
+    }
 
-        if (result.Length > 0 && result[^1] == KebabCaseSeparator)
+    private static void ProcessKebabCharacter(StringBuilder builder, char character, ref bool lastCharWasLowerCase, ref bool lastCharWasSeparator)
+    {
+        if (!char.IsLetterOrDigit(character))
+        {
+            if (CanAppendKebabSeparator(builder, lastCharWasSeparator, character))
+            {
+                builder.Append(KebabCaseSeparator);
+                lastCharWasSeparator = true;
+            }
+        }
+        else if (char.IsUpper(character))
+        {
+            AppendUpperCharAsKebab(builder, character, lastCharWasLowerCase, lastCharWasSeparator);
+            lastCharWasLowerCase = false;
+            lastCharWasSeparator = false;
+        }
+        else
+        {
+            builder.Append(character);
+            lastCharWasLowerCase = true;
+            lastCharWasSeparator = false;
+        }
+    }
+
+    private static void AppendUpperCharAsKebab(StringBuilder builder, char character, bool lastCharWasLowerCase, bool lastCharWasSeparator)
+    {
+        if (lastCharWasLowerCase && !lastCharWasSeparator)
+        {
+            builder.Append(KebabCaseSeparator);
+        }
+
+        builder.Append(char.ToLower(character, CultureInfo.InvariantCulture));
+    }
+
+    private static string TrimTrailingSeparator(string result, char separator)
+    {
+        if (result.Length > 0 && result[^1] == separator)
         {
             return result[..^1];
         }

--- a/src/BuildingBlocks/Persistence.PostgreSql/Factories/EntityInfoFactory.cs
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Factories/EntityInfoFactory.cs
@@ -1,6 +1,0 @@
-namespace Bedrock.BuildingBlocks.Persistence.PostgreSql.Factories;
-
-public class EntityInfoFactory
-{
-
-}

--- a/src/BuildingBlocks/Serialization.Avro/AvroSerializerBase.cs
+++ b/src/BuildingBlocks/Serialization.Avro/AvroSerializerBase.cs
@@ -350,7 +350,7 @@ public abstract class AvroSerializerBase
             _ when underlyingType == typeof(uint) => (uint)Convert.ToInt64(avroValue, CultureInfo.InvariantCulture),
             _ when underlyingType == typeof(ulong) => (ulong)Convert.ToInt64(avroValue, CultureInfo.InvariantCulture),
             _ when underlyingType == typeof(decimal) => decimal.Parse(avroValue.ToString()!, CultureInfo.InvariantCulture),
-            _ when underlyingType == typeof(DateTime) => new DateTime(Convert.ToInt64(avroValue, CultureInfo.InvariantCulture)),
+            _ when underlyingType == typeof(DateTime) => new DateTime(Convert.ToInt64(avroValue, CultureInfo.InvariantCulture), DateTimeKind.Utc),
             _ when underlyingType == typeof(DateTimeOffset) => new DateTimeOffset(Convert.ToInt64(avroValue, CultureInfo.InvariantCulture), TimeSpan.Zero),
             _ when underlyingType == typeof(DateOnly) => DateOnly.FromDayNumber(Convert.ToInt32(avroValue, CultureInfo.InvariantCulture)),
             _ when underlyingType == typeof(TimeOnly) => new TimeOnly(Convert.ToInt64(avroValue, CultureInfo.InvariantCulture)),

--- a/tests/UnitTests/BuildingBlocks/Domain.Entities/EntityBaseTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Domain.Entities/EntityBaseTests.cs
@@ -1276,7 +1276,7 @@ public class EntityBaseTests : TestBase
             id: Id.GenerateNewId(),
             tenantInfo: TenantInfo.Create(Guid.NewGuid(), "Tenant"),
             createdAt: DateTimeOffset.UtcNow,
-            createdBy: null, // This should fail because CreatedByIsRequired defaults to true
+            createdBy: null!, // Intentionally passing null to test validation - CS8625 suppressed
             createdCorrelationId: Guid.NewGuid(),
             createdExecutionOrigin: "System",
             createdBusinessOperationCode: "OP",


### PR DESCRIPTION
## Summary

- Resolve 4 SonarCloud issues with code fixes
- Mark 36 false positives/won't fix via SonarCloud API

## Code Fixes

| File | Rule | Fix |
|------|------|-----|
| `EntityInfoFactory.cs` | S2094 | Remove empty class |
| `AvroSerializerBase.cs` | S6562 | Add `DateTimeKind.Utc` |
| `StringExtensions.cs` | S3776 | Refactor to reduce complexity from 16 to 7 |
| `EntityBaseTests.cs` | CS8625 | Use `null!` for intentional test |

## False Positives Marked via API (36)

| Rule | Count | Reason |
|------|-------|--------|
| S2325 | 9 | C# 14 extension member syntax not supported |
| S3236 | 16 | Intentional `nameof()` for better error messages |
| S1450 | 2 | Fields are cached strings for performance |
| S1905 | 2 | Casts required by Parquet API |
| S125 | 1 | Documentation with code examples, not commented code |
| S107 | 3 | Factory methods need all parameters |
| S3776 | 1 | Type conversion complexity is inherent |
| S2925 | 1 | Thread.Sleep necessary for timer testing |
| S3267 | 1 | StringBuilder more performant than LINQ |

## Test plan

- [x] Pipeline local passa (build, tests, mutation)
- [x] SonarCloud issues marcadas via API
- [ ] GitHub Actions CI/CD passa
- [ ] SonarCloud Quality Gate passa

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)