### PR TITLE
feat: implement SimpleAggregateRootPostgreSqlRepository domain repository bridge

### DIFF
--- a/templates/Infra.Data.PostgreSql/Factories/SimpleAggregateRootFactory.cs
+++ b/templates/Infra.Data.PostgreSql/Factories/SimpleAggregateRootFactory.cs
@@ -1,0 +1,39 @@
+using Bedrock.BuildingBlocks.Core.BirthDates;
+using Bedrock.BuildingBlocks.Core.Ids;
+using Bedrock.BuildingBlocks.Core.RegistryVersions;
+using Bedrock.BuildingBlocks.Core.TenantInfos;
+using Bedrock.BuildingBlocks.Domain.Entities.Models;
+using Templates.Domain.Entities.SimpleAggregateRoots;
+using Templates.Domain.Entities.SimpleAggregateRoots.Inputs;
+using Templates.Infra.Data.PostgreSql.DataModels;
+
+namespace Templates.Infra.Data.PostgreSql.Factories;
+
+public static class SimpleAggregateRootFactory
+{
+    public static SimpleAggregateRoot Create(SimpleAggregateRootDataModel dataModel)
+    {
+        EntityInfo entityInfo = EntityInfo.CreateFromExistingInfo(
+            id: Id.CreateFromExistingInfo(dataModel.Id),
+            tenantInfo: TenantInfo.Create(dataModel.TenantCode),
+            createdAt: dataModel.CreatedAt,
+            createdBy: dataModel.CreatedBy,
+            createdCorrelationId: Guid.Empty,
+            createdExecutionOrigin: string.Empty,
+            createdBusinessOperationCode: string.Empty,
+            lastChangedAt: dataModel.LastChangedAt,
+            lastChangedBy: dataModel.LastChangedBy,
+            lastChangedCorrelationId: dataModel.LastChangedCorrelationId,
+            lastChangedExecutionOrigin: dataModel.LastChangedExecutionOrigin,
+            lastChangedBusinessOperationCode: dataModel.LastChangedBusinessOperationCode,
+            entityVersion: RegistryVersion.CreateFromExistingInfo(dataModel.EntityVersion));
+
+        return SimpleAggregateRoot.CreateFromExistingInfo(
+            new CreateFromExistingInfoInput(
+                entityInfo,
+                dataModel.FirstName,
+                dataModel.LastName,
+                dataModel.FullName,
+                BirthDate.CreateNew(dataModel.BirthDate)));
+    }
+}

--- a/templates/Infra.Data.PostgreSql/Repositories/SimpleAggregateRootPostgreSqlRepository.cs
+++ b/templates/Infra.Data.PostgreSql/Repositories/SimpleAggregateRootPostgreSqlRepository.cs
@@ -1,7 +1,11 @@
 using Bedrock.BuildingBlocks.Core.Ids;
 using Bedrock.BuildingBlocks.Core.Paginations;
 using Bedrock.BuildingBlocks.Domain.Repositories;
+using Bedrock.BuildingBlocks.Persistence.Abstractions.Repositories;
 using Templates.Domain.Entities.SimpleAggregateRoots;
+using Templates.Infra.Data.PostgreSql.DataModels;
+using Templates.Infra.Data.PostgreSql.DataModelsRepositories.Interfaces;
+using Templates.Infra.Data.PostgreSql.Factories;
 using Templates.Infra.Data.PostgreSql.Repositories.Interfaces;
 
 namespace Templates.Infra.Data.PostgreSql.Repositories;
@@ -9,28 +13,91 @@ namespace Templates.Infra.Data.PostgreSql.Repositories;
 public class SimpleAggregateRootPostgreSqlRepository
     : ISimpleAggregateRootPostgreSqlRepository
 {
-    public Task<bool> EnumerateAllAsync(ExecutionContext executionContext, PaginationInfo paginationInfo, ItemHandler<SimpleAggregateRoot> handler, CancellationToken cancellationToken)
+    private readonly ISimpleAggregateRootDataModelRepository _dataModelRepository;
+
+    public SimpleAggregateRootPostgreSqlRepository(
+        ISimpleAggregateRootDataModelRepository dataModelRepository)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(dataModelRepository);
+
+        _dataModelRepository = dataModelRepository;
     }
 
-    public Task<bool> EnumerateModifiedSinceAsync(ExecutionContext executionContext, TimeProvider timeProvider, DateTimeOffset since, ItemHandler<SimpleAggregateRoot> handler, CancellationToken cancellationToken)
+    public async Task<SimpleAggregateRoot?> GetByIdAsync(
+        ExecutionContext executionContext,
+        Id id,
+        CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        SimpleAggregateRootDataModel? dataModel = await _dataModelRepository.GetByIdAsync(
+            executionContext,
+            id,
+            cancellationToken);
+
+        if (dataModel is null)
+            return null;
+
+        return SimpleAggregateRootFactory.Create(dataModel);
     }
 
-    public Task<bool> ExistsAsync(ExecutionContext executionContext, Id id, CancellationToken cancellationToken)
+    public Task<bool> ExistsAsync(
+        ExecutionContext executionContext,
+        Id id,
+        CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        return _dataModelRepository.ExistsAsync(
+            executionContext,
+            id,
+            cancellationToken);
     }
 
-    public Task<SimpleAggregateRoot?> GetByIdAsync(ExecutionContext executionContext, Id id, CancellationToken cancellationToken)
+    public Task<bool> RegisterNewAsync(
+        ExecutionContext executionContext,
+        SimpleAggregateRoot aggregateRoot,
+        CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        SimpleAggregateRootDataModel dataModel = SimpleAggregateRootDataModelFactory.Create(aggregateRoot);
+
+        return _dataModelRepository.InsertAsync(
+            executionContext,
+            dataModel,
+            cancellationToken);
     }
 
-    public Task<bool> RegisterNewAsync(ExecutionContext executionContext, SimpleAggregateRoot aggregateRoot, CancellationToken cancellationToken)
+    public Task<bool> EnumerateAllAsync(
+        ExecutionContext executionContext,
+        PaginationInfo paginationInfo,
+        ItemHandler<SimpleAggregateRoot> handler,
+        CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        return _dataModelRepository.EnumerateAllAsync(
+            executionContext,
+            paginationInfo,
+            CreateDataModelHandler(executionContext, handler),
+            cancellationToken);
+    }
+
+    public Task<bool> EnumerateModifiedSinceAsync(
+        ExecutionContext executionContext,
+        TimeProvider timeProvider,
+        DateTimeOffset since,
+        ItemHandler<SimpleAggregateRoot> handler,
+        CancellationToken cancellationToken)
+    {
+        return _dataModelRepository.EnumerateModifiedSinceAsync(
+            executionContext,
+            since,
+            CreateDataModelHandler(executionContext, handler),
+            cancellationToken);
+    }
+
+    private static DataModelItemHandler<SimpleAggregateRootDataModel> CreateDataModelHandler(
+        ExecutionContext executionContext,
+        ItemHandler<SimpleAggregateRoot> handler)
+    {
+        return async (dataModel, cancellationToken) =>
+        {
+            SimpleAggregateRoot entity = SimpleAggregateRootFactory.Create(dataModel);
+            return await handler(executionContext, entity, cancellationToken);
+        };
     }
 }


### PR DESCRIPTION
## Summary
- Implements `SimpleAggregateRootPostgreSqlRepository` that bridges domain aggregate roots with the PostgreSQL data model repository layer
- Adds `SimpleAggregateRootFactory` to convert `SimpleAggregateRootDataModel` to `SimpleAggregateRoot` domain entity
- Enables full CRUD operations through the repository pattern while maintaining clean separation of concerns

## Changes
- **SimpleAggregateRootFactory**: New factory class that converts DataModel to domain Entity using `CreateFromExistingInfo` pattern
- **SimpleAggregateRootPostgreSqlRepository**: Implements all `IRepository<SimpleAggregateRoot>` methods:
  - `GetByIdAsync` - Retrieves entity by ID
  - `ExistsAsync` - Checks if entity exists
  - `RegisterNewAsync` - Persists new aggregate root
  - `EnumerateAllAsync` - Enumerates all entities with pagination
  - `EnumerateModifiedSinceAsync` - Enumerates entities modified since a timestamp

## Architecture

```mermaid
graph LR
    A[Domain Layer] --> B[SimpleAggregateRootPostgreSqlRepository]
    B --> C[ISimpleAggregateRootDataModelRepository]
    C --> D[PostgreSQL]
    B --> E[SimpleAggregateRootDataModelFactory]
    B --> F[SimpleAggregateRootFactory]
```

## Test plan
- [ ] Build passes locally
- [ ] Pipeline passes (unit tests, mutation tests)
- [ ] Code follows existing patterns in the codebase

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)