### PR TITLE
refactor: create specific handler delegates for enumeration methods

### DIFF
--- a/src/BuildingBlocks/Data/Repositories/RepositoryBase.cs
+++ b/src/BuildingBlocks/Data/Repositories/RepositoryBase.cs
@@ -109,14 +109,14 @@ public abstract class RepositoryBase<TAggregateRoot>
     public async Task<bool> EnumerateAllAsync(
         ExecutionContext executionContext,
         PaginationInfo paginationInfo,
-        ItemHandler<TAggregateRoot> handler,
+        EnumerateAllItemHandler<TAggregateRoot> handler,
         CancellationToken cancellationToken)
     {
         try
         {
             await foreach (var item in GetAllInternalAsync(paginationInfo, cancellationToken))
             {
-                var shouldContinue = await handler(executionContext, item, cancellationToken);
+                var shouldContinue = await handler(executionContext, item, paginationInfo, cancellationToken);
                 if (!shouldContinue)
                     break;
             }
@@ -202,14 +202,14 @@ public abstract class RepositoryBase<TAggregateRoot>
         ExecutionContext executionContext,
         TimeProvider timeProvider,
         DateTimeOffset since,
-        ItemHandler<TAggregateRoot> handler,
+        EnumerateModifiedSinceItemHandler<TAggregateRoot> handler,
         CancellationToken cancellationToken)
     {
         try
         {
             await foreach (var item in GetModifiedSinceInternalAsync(executionContext, timeProvider, since, cancellationToken))
             {
-                var shouldContinue = await handler(executionContext, item, cancellationToken);
+                var shouldContinue = await handler(executionContext, item, timeProvider, since, cancellationToken);
                 if (!shouldContinue)
                     break;
             }

--- a/templates/Infra.Data.PostgreSql/Repositories/SimpleAggregateRootPostgreSqlRepository.cs
+++ b/templates/Infra.Data.PostgreSql/Repositories/SimpleAggregateRootPostgreSqlRepository.cs
@@ -66,13 +66,13 @@ public class SimpleAggregateRootPostgreSqlRepository
     public Task<bool> EnumerateAllAsync(
         ExecutionContext executionContext,
         PaginationInfo paginationInfo,
-        ItemHandler<SimpleAggregateRoot> handler,
+        EnumerateAllItemHandler<SimpleAggregateRoot> handler,
         CancellationToken cancellationToken)
     {
         return _dataModelRepository.EnumerateAllAsync(
             executionContext,
             paginationInfo,
-            CreateDataModelHandler(executionContext, handler),
+            CreateEnumerateAllDataModelHandler(executionContext, paginationInfo, handler),
             cancellationToken);
     }
 
@@ -80,24 +80,38 @@ public class SimpleAggregateRootPostgreSqlRepository
         ExecutionContext executionContext,
         TimeProvider timeProvider,
         DateTimeOffset since,
-        ItemHandler<SimpleAggregateRoot> handler,
+        EnumerateModifiedSinceItemHandler<SimpleAggregateRoot> handler,
         CancellationToken cancellationToken)
     {
         return _dataModelRepository.EnumerateModifiedSinceAsync(
             executionContext,
             since,
-            CreateDataModelHandler(executionContext, handler),
+            CreateEnumerateModifiedSinceDataModelHandler(executionContext, timeProvider, since, handler),
             cancellationToken);
     }
 
-    private static DataModelItemHandler<SimpleAggregateRootDataModel> CreateDataModelHandler(
+    private static DataModelItemHandler<SimpleAggregateRootDataModel> CreateEnumerateAllDataModelHandler(
         ExecutionContext executionContext,
-        ItemHandler<SimpleAggregateRoot> handler)
+        PaginationInfo paginationInfo,
+        EnumerateAllItemHandler<SimpleAggregateRoot> handler)
     {
         return async (dataModel, cancellationToken) =>
         {
             SimpleAggregateRoot entity = SimpleAggregateRootFactory.Create(dataModel);
-            return await handler(executionContext, entity, cancellationToken);
+            return await handler(executionContext, entity, paginationInfo, cancellationToken);
+        };
+    }
+
+    private static DataModelItemHandler<SimpleAggregateRootDataModel> CreateEnumerateModifiedSinceDataModelHandler(
+        ExecutionContext executionContext,
+        TimeProvider timeProvider,
+        DateTimeOffset since,
+        EnumerateModifiedSinceItemHandler<SimpleAggregateRoot> handler)
+    {
+        return async (dataModel, cancellationToken) =>
+        {
+            SimpleAggregateRoot entity = SimpleAggregateRootFactory.Create(dataModel);
+            return await handler(executionContext, entity, timeProvider, since, cancellationToken);
         };
     }
 }

--- a/tests/UnitTests/BuildingBlocks/Data/Repositories/RepositoryBaseTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Data/Repositories/RepositoryBaseTests.cs
@@ -114,7 +114,7 @@ public class RepositoryBaseTests : TestBase
         var result = await repository.EnumerateAllAsync(
             _executionContext,
             _paginationInfo,
-            (ctx, item, ct) =>
+            (ctx, item, pagination, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(true);
@@ -152,7 +152,7 @@ public class RepositoryBaseTests : TestBase
         var result = await repository.EnumerateAllAsync(
             _executionContext,
             _paginationInfo,
-            (ctx, item, ct) =>
+            (ctx, item, pagination, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(processedItems.Count < 2);
@@ -184,7 +184,7 @@ public class RepositoryBaseTests : TestBase
         var result = await repository.EnumerateAllAsync(
             _executionContext,
             _paginationInfo,
-            (ctx, item, ct) =>
+            (ctx, item, pagination, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(true);
@@ -222,7 +222,7 @@ public class RepositoryBaseTests : TestBase
         var result = await repository.EnumerateAllAsync(
             _executionContext,
             _paginationInfo,
-            (ctx, item, ct) =>
+            (ctx, item, pagination, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(true);
@@ -261,7 +261,7 @@ public class RepositoryBaseTests : TestBase
         var result = await repository.EnumerateAllAsync(
             _executionContext,
             _paginationInfo,
-            (ctx, item, ct) =>
+            (ctx, item, pagination, ct) =>
             {
                 handlerCalled = true;
                 return Task.FromResult(true);
@@ -523,7 +523,7 @@ public class RepositoryBaseTests : TestBase
             _executionContext,
             _timeProvider,
             _sinceDate,
-            (ctx, item, ct) =>
+            (ctx, item, tp, since, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(true);
@@ -563,7 +563,7 @@ public class RepositoryBaseTests : TestBase
             _executionContext,
             _timeProvider,
             _sinceDate,
-            (ctx, item, ct) =>
+            (ctx, item, tp, since, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(false);
@@ -595,7 +595,7 @@ public class RepositoryBaseTests : TestBase
             _executionContext,
             _timeProvider,
             _sinceDate,
-            (ctx, item, ct) =>
+            (ctx, item, tp, since, ct) =>
             {
                 processedItems.Add(item);
                 return Task.FromResult(true);
@@ -634,7 +634,7 @@ public class RepositoryBaseTests : TestBase
             _executionContext,
             _timeProvider,
             _sinceDate,
-            (ctx, item, ct) =>
+            (ctx, item, tp, since, ct) =>
             {
                 handlerCalled = true;
                 return Task.FromResult(true);


### PR DESCRIPTION
## Summary
- Create `EnumerateAllItemHandler<T>` delegate with signature `(ExecutionContext, T item, PaginationInfo, CancellationToken)`
- Create `EnumerateModifiedSinceItemHandler<T>` delegate with signature `(ExecutionContext, T item, TimeProvider, DateTimeOffset since, CancellationToken)`
- Update `IRepository<T>`, `RepositoryBase<T>`, and `SimpleAggregateRootPostgreSqlRepository` to use the new delegates
- Update unit tests to use the new handler signatures

This change eliminates the need for closures when clients need access to method-specific parameters (like `PaginationInfo`, `TimeProvider`, or `since` timestamp) within the handler callback.

Closes #70

## Test plan
- [x] Pipeline local executada com sucesso
- [x] Build compila sem erros
- [x] Testes unitários passam
- [x] Testes de mutação passam (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)