### PR TITLE
feat(core): add ISpanFormattable to EmailAddress for zero-allocation formatting

### DIFF
--- a/src/BuildingBlocks/Core/EmailAddresses/EmailAddress.cs
+++ b/src/BuildingBlocks/Core/EmailAddresses/EmailAddress.cs
@@ -1,7 +1,7 @@
 namespace Bedrock.BuildingBlocks.Core.EmailAddresses;
 
 public readonly struct EmailAddress
-    : IEquatable<EmailAddress>
+    : IEquatable<EmailAddress>, IFormattable, ISpanFormattable
 {
     public string Value { get; }
 
@@ -35,6 +35,30 @@ public readonly struct EmailAddress
     public override string ToString()
     {
         return Value;
+    }
+
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return Value;
+    }
+
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        if (Value is null)
+        {
+            charsWritten = 0;
+            return true;
+        }
+
+        if (destination.Length < Value.Length)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        Value.AsSpan().CopyTo(destination);
+        charsWritten = Value.Length;
+        return true;
     }
 
     public override int GetHashCode()


### PR DESCRIPTION
## Summary
- Implement `IFormattable` and `ISpanFormattable` interfaces on `EmailAddress` struct
- Add `ToString(string?, IFormatProvider?)` for IFormattable compatibility
- Add `TryFormat` for `Span<char>` based zero-allocation formatting
- Handle null Value gracefully (returns true with 0 chars written)

## Test plan
- [x] `ToString(format, provider)` returns value
- [x] `TryFormat` succeeds with sufficient buffer
- [x] `TryFormat` returns false with insufficient buffer
- [x] `TryFormat` succeeds with exact-size buffer
- [x] `TryFormat` handles null value correctly
- [x] All 39 EmailAddress tests pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)