### PR TITLE
refactor(core): improve thread safety in ExecutionContextAccessor

### DIFF
--- a/src/BuildingBlocks/Core/ExecutionContexts/ExecutionContextAccessor.cs
+++ b/src/BuildingBlocks/Core/ExecutionContexts/ExecutionContextAccessor.cs
@@ -2,11 +2,13 @@ namespace Bedrock.BuildingBlocks.Core.ExecutionContexts;
 
 public class ExecutionContextAccessor : IExecutionContextAccessor
 {
-    public ExecutionContext? Current { get; private set; }
+    private volatile ExecutionContext? _current;
+
+    public ExecutionContext? Current => _current;
 
     public void SetCurrent(ExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        Current = context;
+        _current = context;
     }
 }


### PR DESCRIPTION
## Summary
- Use `volatile` field to ensure proper memory visibility across threads
- Replace auto-property with explicit backing field for thread-safe access

## Test plan
- [x] Existing tests pass (9 tests)
- [x] New concurrent write test validates thread safety
- [x] New concurrent read test validates consistent reads
- [x] All 11 ExecutionContextAccessor tests pass

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)