### PR TITLE
feat(core): add ISpanFormattable to Id for zero-allocation formatting

### DIFF
--- a/src/BuildingBlocks/Core/Ids/Id.cs
+++ b/src/BuildingBlocks/Core/Ids/Id.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 namespace Bedrock.BuildingBlocks.Core.Ids;
 
 public readonly struct Id
-    : IEquatable<Id>, IComparable<Id>
+    : IEquatable<Id>, IComparable<Id>, ISpanFormattable, IUtf8SpanFormattable
 {
     [ThreadStatic] private static long _lastTimestamp;
     [ThreadStatic] private static long _counter;
@@ -83,6 +83,34 @@ public readonly struct Id
     public int CompareTo(Id other)
     {
         return Value.CompareTo(other.Value);
+    }
+
+    public override string ToString()
+    {
+        return Value.ToString();
+    }
+
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return Value.ToString(format, formatProvider);
+    }
+
+    public bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return Value.TryFormat(destination, out charsWritten, format);
+    }
+
+    public bool TryFormat(
+        Span<byte> utf8Destination,
+        out int bytesWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return Value.TryFormat(utf8Destination, out bytesWritten, format);
     }
 
     public static implicit operator Guid(Id id)


### PR DESCRIPTION
## Summary
- Add `ISpanFormattable` and `IUtf8SpanFormattable` interfaces to `Id` struct for zero-allocation formatting
- Implement `ToString()`, `ToString(string?, IFormatProvider?)`, and `TryFormat()` methods that delegate to the underlying `Guid`
- Add comprehensive tests for all formatting scenarios (sufficient buffer, insufficient buffer, exact size, N format, UTF-8)

## Test plan
- [x] All existing Id tests pass
- [x] New TryFormat tests for Span<char> with various buffer sizes
- [x] New TryFormat tests for Span<byte> (UTF-8) with various buffer sizes
- [x] Format specifier tests (N, D, B, P, X)
- [x] Pipeline local passou (100% cobertura, 100% mutação)

🤖 Generated with [Claude Code](https://claude.com/claude-code)