### PR TITLE
perf(domain): add zero-allocation caching to EntityBase<T>

### DIFF
--- a/src/BuildingBlocks/Domain.Entities/EntityBase.cs
+++ b/src/BuildingBlocks/Domain.Entities/EntityBase.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Bedrock.BuildingBlocks.Core.ExecutionContexts;
 using Bedrock.BuildingBlocks.Core.TenantInfos;
@@ -471,7 +472,8 @@ public abstract class EntityBase : IEntity
 /// <typeparam name="TEntity">The entity type.</typeparam>
 public abstract class EntityBase<TEntity> : EntityBase, IEntity<TEntity>
 {
-    private readonly Type _entityType = typeof(TEntity);
+    private static readonly string EntityTypeName = typeof(TEntity).ToString();
+    private static readonly ConcurrentDictionary<string, string> MessageCodeCache = new();
 
     /// <summary>
     /// Initializes a new instance of the EntityBase class.
@@ -577,6 +579,9 @@ public abstract class EntityBase<TEntity> : EntityBase, IEntity<TEntity>
     /// <inheritdoc/>
     protected override string CreateMessageCode(string messageSuffix)
     {
-        return $"{_entityType}.{messageSuffix}";
+        return MessageCodeCache.GetOrAdd(
+            messageSuffix,
+            static (suffix, typeName) => string.Concat(typeName, ".", suffix),
+            EntityTypeName);
     }
 }


### PR DESCRIPTION
## Summary
- Replace per-instance `Type` field with static `string` to save 8 bytes per entity instance
- Add `ConcurrentDictionary` cache for message codes to eliminate string allocations in `CreateMessageCode`
- Use `string.Concat` instead of interpolation for the cache factory delegate

## Test plan
- [x] Pipeline local passou com sucesso
- [x] Todos os testes unitários passando
- [x] Todos os testes de mutação passando (100%)

🤖 Generated with [Claude Code](https://claude.ai/code)