### PR TITLE
perf(persistence): use Convert.ToHexStringLower for zero-allocation in IdUtils

### DIFF
--- a/src/BuildingBlocks/Persistence.Abstractions/Utils/IdUtils.cs
+++ b/src/BuildingBlocks/Persistence.Abstractions/Utils/IdUtils.cs
@@ -42,7 +42,7 @@ public static class IdUtils
             }
         }
 
-        return Convert.ToHexString(guidBytes[..12]).ToLowerInvariant();
+        return Convert.ToHexStringLower(guidBytes[..12]);
     }
 
     private static int GetHexVal(char hex)


### PR DESCRIPTION
## Summary
- Replace `Convert.ToHexString().ToLowerInvariant()` with `Convert.ToHexStringLower()` in `IdUtils.GuidToHexId()`
- Eliminates intermediate string allocation by using .NET 8+ API that returns lowercase directly

## Test plan
- [x] Pipeline local passou (build, testes, cobertura, mutação)
- [x] 46 testes unitários de IdUtils passaram
- [x] Build de Persistence.PostgreSql validado (sem impacto - assinatura não mudou)

🤖 Generated with [Claude Code](https://claude.com/claude-code)