### PR TITLE
perf(persistence): add zero-allocation caching to DataModelMapperBase

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.1" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 
     <!-- Serialization -->

--- a/src/BuildingBlocks/Persistence.PostgreSql/Bedrock.BuildingBlocks.Persistence.PostgreSql.csproj
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Bedrock.BuildingBlocks.Persistence.PostgreSql.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="Npgsql" />
   </ItemGroup>
 

--- a/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/MapperOptions.cs
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/MapperOptions.cs
@@ -10,6 +10,7 @@ public class MapperOptions<TDataModel>
 {
     // Fields
     private readonly Dictionary<string, ColumnMap> _fieldDictionary = [];
+    private ReadOnlyDictionary<string, ColumnMap>? _fieldDictionaryReadOnly;
 
     // Properties
     public string? TableSchema { get; private set; }
@@ -18,7 +19,8 @@ public class MapperOptions<TDataModel>
     {
         get
         {
-            return _fieldDictionary.AsReadOnly();
+            // Stryker disable once all : Cache null-coalescing - mutante equivalente (apenas afeta primeira chamada)
+            return _fieldDictionaryReadOnly ??= _fieldDictionary.AsReadOnly();
         }
     }
 

--- a/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/OrderByClause.cs
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/OrderByClause.cs
@@ -18,7 +18,18 @@ public readonly struct OrderByClause
     // Operators
     public static OrderByClause operator +(OrderByClause left, OrderByClause right)
     {
-        return new OrderByClause($"{left.Value}, {right.Value}");
+        return new OrderByClause(string.Create(
+            left.Value.Length + 2 + right.Value.Length,
+            (left.Value, right.Value),
+            static (span, state) =>
+            {
+                int pos = 0;
+                state.Item1.AsSpan().CopyTo(span);
+                pos += state.Item1.Length;
+                ", ".AsSpan().CopyTo(span[pos..]);
+                pos += 2;
+                state.Item2.AsSpan().CopyTo(span[pos..]);
+            }));
     }
 
     // Methods

--- a/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/WhereClause.cs
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Models/WhereClause.cs
@@ -18,12 +18,37 @@ public readonly struct WhereClause
     // Operators
     public static WhereClause operator &(WhereClause left, WhereClause right)
     {
-        return new WhereClause($"{left.Value} AND {right.Value}");
+        return new WhereClause(string.Create(
+            left.Value.Length + 5 + right.Value.Length,
+            (left.Value, right.Value),
+            static (span, state) =>
+            {
+                int pos = 0;
+                state.Item1.AsSpan().CopyTo(span);
+                pos += state.Item1.Length;
+                " AND ".AsSpan().CopyTo(span[pos..]);
+                pos += 5;
+                state.Item2.AsSpan().CopyTo(span[pos..]);
+            }));
     }
 
     public static WhereClause operator |(WhereClause left, WhereClause right)
     {
-        return new WhereClause($"({left.Value} OR {right.Value})");
+        return new WhereClause(string.Create(
+            1 + left.Value.Length + 4 + right.Value.Length + 1,
+            (left.Value, right.Value),
+            static (span, state) =>
+            {
+                span[0] = '(';
+                int pos = 1;
+                state.Item1.AsSpan().CopyTo(span[pos..]);
+                pos += state.Item1.Length;
+                " OR ".AsSpan().CopyTo(span[pos..]);
+                pos += 4;
+                state.Item2.AsSpan().CopyTo(span[pos..]);
+                pos += state.Item2.Length;
+                span[pos] = ')';
+            }));
     }
 
     // Methods


### PR DESCRIPTION
## Summary
- Add caching mechanisms for parameter names, WHERE clauses, and ORDER BY clauses
- Use `string.Create` with `SpanAction` for zero-allocation string building in clause operators
- Use `StringBuilder` pooling via `Microsoft.Extensions.ObjectPool` for `Generate*Command` methods
- Replace LINQ with `foreach` loops in `CacheGeneratedStrings` to eliminate iterator allocations
- Cache `ReadOnlyDictionary` in `MapperOptions` to avoid repeated wrapper creation

## Test plan
- [x] Pipeline local passou com 100% de cobertura
- [x] Pipeline local passou com 100% de mutação
- [ ] Aguardar pipeline do GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)