### PR TITLE
chore(scripts): add integration tests step to local pipeline

### DIFF
--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Executa a pipeline completa: clean → build → test → mutate
+# Executa a pipeline completa: clean → build → test → mutate → integration
 # Gera artifacts/summary.json com resultados consolidados
 
 set -e
@@ -17,13 +17,13 @@ echo "========================================"
 echo ""
 
 # === CLEAN ===
-echo ">>> Step 1/4: Clean"
+echo ">>> Step 1/5: Clean"
 "$SCRIPT_DIR/clean.sh"
 "$SCRIPT_DIR/clean-artifacts.sh"
 echo ""
 
 # === BUILD ===
-echo ">>> Step 2/4: Build"
+echo ">>> Step 2/5: Build"
 BUILD_START=$(date +%s%3N)
 "$SCRIPT_DIR/build.sh"
 BUILD_END=$(date +%s%3N)
@@ -31,7 +31,7 @@ BUILD_DURATION=$((BUILD_END - BUILD_START))
 echo ""
 
 # === TEST ===
-echo ">>> Step 3/4: Test"
+echo ">>> Step 3/5: Test"
 TEST_START=$(date +%s%3N)
 "$SCRIPT_DIR/test.sh"
 TEST_END=$(date +%s%3N)
@@ -39,13 +39,49 @@ TEST_DURATION=$((TEST_END - TEST_START))
 echo ""
 
 # === MUTATE ===
-echo ">>> Step 4/4: Mutate"
+echo ">>> Step 4/5: Mutate"
 MUTATE_START=$(date +%s%3N)
 MUTATION_FAILED=0
 "$SCRIPT_DIR/mutate.sh" || MUTATION_FAILED=1
 MUTATE_END=$(date +%s%3N)
 MUTATE_DURATION=$((MUTATE_END - MUTATE_START))
 echo ""
+
+# === INTEGRATION TESTS ===
+# Only run if mutation tests passed (100% coverage and 100% mutation required)
+INTEGRATION_FAILED=0
+INTEGRATION_DURATION=0
+INTEGRATION_PROJECTS_COUNT=0
+
+if [ $MUTATION_FAILED -eq 0 ]; then
+    echo ">>> Step 5/5: Integration Tests"
+    INTEGRATION_START=$(date +%s%3N)
+
+    # Find all integration test projects dynamically
+    INTEGRATION_PROJECTS=$(find tests/IntegrationTests -name "*.csproj" 2>/dev/null)
+
+    if [ -n "$INTEGRATION_PROJECTS" ]; then
+        for project in $INTEGRATION_PROJECTS; do
+            INTEGRATION_PROJECTS_COUNT=$((INTEGRATION_PROJECTS_COUNT + 1))
+            name=$(basename "$(dirname "$project")")
+            echo "Running integration tests for: $name"
+
+            if ! dotnet test "$project" --no-build --logger "trx;LogFileName=integration-$name.trx" --results-directory "artifacts/test-results"; then
+                INTEGRATION_FAILED=1
+                echo "FAILED: Integration tests failed for $name"
+            fi
+        done
+    else
+        echo "No integration test projects found in tests/IntegrationTests"
+    fi
+
+    INTEGRATION_END=$(date +%s%3N)
+    INTEGRATION_DURATION=$((INTEGRATION_END - INTEGRATION_START))
+    echo ""
+else
+    echo ">>> Step 5/5: Integration Tests (SKIPPED - mutation tests failed)"
+    echo ""
+fi
 
 END_TIME=$(date +%s%3N)
 TOTAL_DURATION=$((END_TIME - START_TIME))
@@ -92,6 +128,12 @@ cat > artifacts/summary.json << SUMMARY_EOF
   "mutation": {
     "success": $([ $MUTATION_FAILED -eq 0 ] && echo "true" || echo "false"),
     "duration_ms": $MUTATE_DURATION
+  },
+  "integration": {
+    "success": $([ $INTEGRATION_FAILED -eq 0 ] && echo "true" || echo "false"),
+    "skipped": $([ $MUTATION_FAILED -eq 1 ] && echo "true" || echo "false"),
+    "projects_count": $INTEGRATION_PROJECTS_COUNT,
+    "duration_ms": $INTEGRATION_DURATION
   }
 }
 SUMMARY_EOF
@@ -118,6 +160,14 @@ if [ $MUTATION_FAILED -eq 1 ]; then
     echo "  2. Check individual files in artifacts/pending/ for details"
     echo "  3. Improve test assertions to kill mutants"
     echo "  4. Run pipeline again"
+    exit 1
+elif [ $INTEGRATION_FAILED -eq 1 ]; then
+    echo "STATUS: FAILED (integration tests failed)"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Check test results in artifacts/test-results/"
+    echo "  2. Fix failing integration tests"
+    echo "  3. Run pipeline again"
     exit 1
 else
     echo "STATUS: SUCCESS"


### PR DESCRIPTION
## Summary
- Adiciona step 5/5 de testes de integração à pipeline local
- Testes de integração só executam após 100% de cobertura e 100% de mutação
- Descobre projetos .csproj em `tests/IntegrationTests` dinamicamente
- Atualiza `summary.json` com métricas de integração (success, skipped, projects_count, duration_ms)

## Test plan
- [x] Pipeline local executada com sucesso
- [x] Testes de integração executados após mutação passar
- [x] `summary.json` gerado corretamente com seção `integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)