### PR TITLE
fix(persistence): add PostgreSQL integration tests and fix critical bugs

### DIFF
--- a/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Interfaces/IDataModelMapper.cs
+++ b/src/BuildingBlocks/Persistence.PostgreSql/Mappers/Interfaces/IDataModelMapper.cs
@@ -50,6 +50,8 @@ public interface IDataModelMapper<TDataModel>
     public WhereClause Where<TProperty>(Expression<Func<TDataModel, TProperty>> selector, RelationalOperator op);
     public WhereClause Where(string propertyName);
     public WhereClause Where<TProperty>(Expression<Func<TDataModel, TProperty>> selector);
+    public WhereClause WhereWithParameterSuffix(string propertyName, string parameterSuffix, RelationalOperator op);
+    public WhereClause WhereWithParameterSuffix<TProperty>(Expression<Func<TDataModel, TProperty>> selector, string parameterSuffix, RelationalOperator op);
 
     // Order by clause generation (type-safe)
     public OrderByClause OrderBy(string propertyName, SortDirection direction);
@@ -64,6 +66,7 @@ public interface IDataModelMapper<TDataModel>
     public string GetParameterName<TProperty>(Expression<Func<TDataModel, TProperty>> selector);
     public void AddParameterForCommand(NpgsqlCommand npgsqlCommand, string propertyName, NpgsqlDbType npgsqlDbType, object? value);
     public void AddParameterForCommand<TProperty>(NpgsqlCommand npgsqlCommand, Expression<Func<TDataModel, TProperty>> selector, object? value);
+    public void AddParameterForCommandWithSuffix<TProperty>(NpgsqlCommand npgsqlCommand, Expression<Func<TDataModel, TProperty>> selector, string parameterSuffix, object? value);
 
     // Data model handling
     public void ConfigureCommandToProperty(string propertyName, TDataModel dataModel, NpgsqlCommand npgsqlCommand);

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.csproj
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Connections/TestPostgreSqlConnection.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Connections/TestPostgreSqlConnection.cs
@@ -1,0 +1,29 @@
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Connections;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Connections.Models;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Connections;
+
+/// <summary>
+/// Test PostgreSQL connection implementation for integration tests.
+/// Accepts a connection string in the constructor for flexibility in test scenarios.
+/// </summary>
+public class TestPostgreSqlConnection : PostgreSqlConnectionBase
+{
+    private readonly string _connectionString;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestPostgreSqlConnection"/> class.
+    /// </summary>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    public TestPostgreSqlConnection(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    /// <inheritdoc />
+    protected override void ConfigureInternal(PostgreSqlConnectionOptions options)
+    {
+        options.WithConnectionString(_connectionString);
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/DataModels/TestEntityDataModel.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/DataModels/TestEntityDataModel.cs
@@ -1,0 +1,15 @@
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.DataModels;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.DataModels;
+
+/// <summary>
+/// Test data model for integration tests extending DataModelBase.
+/// Maps to the test_entities table in the PostgreSQL test database.
+/// </summary>
+public class TestEntityDataModel : DataModelBase
+{
+    /// <summary>
+    /// Gets or sets the name of the test entity.
+    /// </summary>
+    public string Name { get; set; } = null!;
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Fixtures/PostgresRepositoryFixture.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Fixtures/PostgresRepositoryFixture.cs
@@ -1,7 +1,18 @@
+using Bedrock.BuildingBlocks.Core.ExecutionContexts;
+using Bedrock.BuildingBlocks.Core.ExecutionContexts.Models.Enums;
+using Bedrock.BuildingBlocks.Core.TenantInfos;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Mappers.Interfaces;
 using Bedrock.BuildingBlocks.Testing;
 using Bedrock.BuildingBlocks.Testing.Integration.Environments;
 using Bedrock.BuildingBlocks.Testing.Integration.Postgres.Permissions;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Connections;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.DataModels;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Mappers;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.UnitOfWork;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
 
@@ -41,10 +52,224 @@ public class PostgresRepositoryFixture : ServiceCollectionFixture
             .GetConnectionString("testdb", user: "readonly_user");
     }
 
+    /// <summary>
+    /// Creates an ExecutionContext for integration tests.
+    /// </summary>
+    /// <param name="tenantCode">Optional tenant code. If not provided, a new GUID is generated.</param>
+    /// <returns>A new ExecutionContext configured for testing.</returns>
+    public Bedrock.BuildingBlocks.Core.ExecutionContexts.ExecutionContext CreateExecutionContext(Guid? tenantCode = null)
+    {
+        return Bedrock.BuildingBlocks.Core.ExecutionContexts.ExecutionContext.Create(
+            correlationId: Guid.NewGuid(),
+            tenantInfo: TenantInfo.Create(tenantCode ?? Guid.NewGuid(), "IntegrationTestTenant"),
+            executionUser: "integration_test_user",
+            executionOrigin: "IntegrationTests",
+            businessOperationCode: "TEST_OPERATION",
+            minimumMessageType: MessageType.Trace,
+            timeProvider: TimeProvider.System
+        );
+    }
+
+    /// <summary>
+    /// Creates a UnitOfWork with the specified connection string.
+    /// </summary>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <returns>A new TestPostgreSqlUnitOfWork instance.</returns>
+    public TestPostgreSqlUnitOfWork CreateUnitOfWork(string connectionString)
+    {
+        var connection = new TestPostgreSqlConnection(connectionString);
+        var logger = GetService<ILoggerFactory>().CreateLogger<TestPostgreSqlUnitOfWork>();
+        return new TestPostgreSqlUnitOfWork(logger, connection);
+    }
+
+    /// <summary>
+    /// Creates a UnitOfWork with app user credentials.
+    /// </summary>
+    /// <returns>A new TestPostgreSqlUnitOfWork instance.</returns>
+    public TestPostgreSqlUnitOfWork CreateAppUserUnitOfWork()
+    {
+        return CreateUnitOfWork(GetAppUserConnectionString());
+    }
+
+    /// <summary>
+    /// Creates a TestEntityRepository with the specified unit of work.
+    /// </summary>
+    /// <param name="unitOfWork">The unit of work for the repository.</param>
+    /// <returns>A new TestEntityRepository instance.</returns>
+    public TestEntityRepository CreateRepository(TestPostgreSqlUnitOfWork unitOfWork)
+    {
+        var logger = GetService<ILoggerFactory>().CreateLogger<TestEntityRepository>();
+        var mapper = GetService<IDataModelMapper<TestEntityDataModel>>();
+        return new TestEntityRepository(logger, unitOfWork, mapper);
+    }
+
+    /// <summary>
+    /// Creates a TestPostgreSqlConnection with the specified connection string.
+    /// </summary>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <returns>A new TestPostgreSqlConnection instance.</returns>
+    public TestPostgreSqlConnection CreateConnection(string connectionString)
+    {
+        return new TestPostgreSqlConnection(connectionString);
+    }
+
+    /// <summary>
+    /// Creates a TestPostgreSqlConnection with app user credentials.
+    /// </summary>
+    /// <returns>A new TestPostgreSqlConnection instance.</returns>
+    public TestPostgreSqlConnection CreateAppUserConnection()
+    {
+        return CreateConnection(GetAppUserConnectionString());
+    }
+
+    /// <summary>
+    /// Creates a TestEntityDataModel with test data.
+    /// </summary>
+    /// <param name="id">Optional entity ID. If not provided, a new GUID is generated.</param>
+    /// <param name="tenantCode">Optional tenant code. If not provided, a new GUID is generated.</param>
+    /// <param name="name">Optional entity name. If not provided, a unique name is generated.</param>
+    /// <param name="entityVersion">The entity version for optimistic concurrency. Defaults to 1.</param>
+    /// <returns>A new TestEntityDataModel instance.</returns>
+    public TestEntityDataModel CreateTestEntity(
+        Guid? id = null,
+        Guid? tenantCode = null,
+        string? name = null,
+        long entityVersion = 1)
+    {
+        return new TestEntityDataModel
+        {
+            Id = id ?? Guid.NewGuid(),
+            TenantCode = tenantCode ?? Guid.NewGuid(),
+            Name = name ?? $"TestEntity_{Guid.NewGuid():N}",
+            CreatedBy = "integration_test_user",
+            CreatedAt = DateTimeOffset.UtcNow,
+            EntityVersion = entityVersion
+        };
+    }
+
+    /// <summary>
+    /// Cleans up test data for a specific tenant.
+    /// </summary>
+    /// <param name="tenantCode">The tenant code to clean up.</param>
+    public async Task CleanupTestDataAsync(Guid tenantCode)
+    {
+        await using var connection = new NpgsqlConnection(GetAdminConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            "DELETE FROM test_entities WHERE tenant_code = @tenantCode",
+            connection);
+        command.Parameters.AddWithValue("tenantCode", tenantCode);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Inserts a test entity directly using raw SQL (bypassing repository).
+    /// Useful for setting up test data.
+    /// </summary>
+    /// <param name="entity">The entity to insert.</param>
+    public async Task InsertTestEntityDirectlyAsync(TestEntityDataModel entity)
+    {
+        await using var connection = new NpgsqlConnection(GetAdminConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            INSERT INTO test_entities (id, tenant_code, name, created_by, created_at,
+                last_changed_by, last_changed_at, last_changed_execution_origin,
+                last_changed_correlation_id, last_changed_business_operation_code, entity_version)
+            VALUES (@id, @tenantCode, @name, @createdBy, @createdAt,
+                @lastChangedBy, @lastChangedAt, @lastChangedExecutionOrigin,
+                @lastChangedCorrelationId, @lastChangedBusinessOperationCode, @entityVersion)
+            """,
+            connection);
+
+        command.Parameters.AddWithValue("id", entity.Id);
+        command.Parameters.AddWithValue("tenantCode", entity.TenantCode);
+        command.Parameters.AddWithValue("name", entity.Name);
+        command.Parameters.AddWithValue("createdBy", entity.CreatedBy);
+        command.Parameters.AddWithValue("createdAt", entity.CreatedAt);
+        command.Parameters.AddWithValue("lastChangedBy", (object?)entity.LastChangedBy ?? DBNull.Value);
+        command.Parameters.AddWithValue("lastChangedAt", (object?)entity.LastChangedAt ?? DBNull.Value);
+        command.Parameters.AddWithValue("lastChangedExecutionOrigin", (object?)entity.LastChangedExecutionOrigin ?? DBNull.Value);
+        command.Parameters.AddWithValue("lastChangedCorrelationId", (object?)entity.LastChangedCorrelationId ?? DBNull.Value);
+        command.Parameters.AddWithValue("lastChangedBusinessOperationCode", (object?)entity.LastChangedBusinessOperationCode ?? DBNull.Value);
+        command.Parameters.AddWithValue("entityVersion", entity.EntityVersion);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Gets a test entity directly using raw SQL (bypassing repository).
+    /// Useful for verifying test results.
+    /// </summary>
+    /// <param name="id">The entity ID.</param>
+    /// <param name="tenantCode">The tenant code.</param>
+    /// <returns>The entity if found, null otherwise.</returns>
+    public async Task<TestEntityDataModel?> GetTestEntityDirectlyAsync(Guid id, Guid tenantCode)
+    {
+        await using var connection = new NpgsqlConnection(GetAdminConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT id, tenant_code, name, created_by, created_at,
+                last_changed_by, last_changed_at, last_changed_execution_origin,
+                last_changed_correlation_id, last_changed_business_operation_code, entity_version
+            FROM test_entities
+            WHERE id = @id AND tenant_code = @tenantCode
+            """,
+            connection);
+
+        command.Parameters.AddWithValue("id", id);
+        command.Parameters.AddWithValue("tenantCode", tenantCode);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        return new TestEntityDataModel
+        {
+            Id = reader.GetGuid(0),
+            TenantCode = reader.GetGuid(1),
+            Name = reader.GetString(2),
+            CreatedBy = reader.GetString(3),
+            CreatedAt = new DateTimeOffset(reader.GetDateTime(4), TimeSpan.Zero),
+            LastChangedBy = reader.IsDBNull(5) ? null : reader.GetString(5),
+            LastChangedAt = reader.IsDBNull(6) ? null : new DateTimeOffset(reader.GetDateTime(6), TimeSpan.Zero),
+            LastChangedExecutionOrigin = reader.IsDBNull(7) ? null : reader.GetString(7),
+            LastChangedCorrelationId = reader.IsDBNull(8) ? null : reader.GetGuid(8),
+            LastChangedBusinessOperationCode = reader.IsDBNull(9) ? null : reader.GetString(9),
+            EntityVersion = reader.GetInt64(10)
+        };
+    }
+
+    /// <summary>
+    /// Updates a test entity version directly using raw SQL (bypassing repository).
+    /// Useful for testing optimistic concurrency.
+    /// </summary>
+    /// <param name="id">The entity ID.</param>
+    /// <param name="tenantCode">The tenant code.</param>
+    /// <param name="newVersion">The new version number.</param>
+    public async Task UpdateEntityVersionDirectlyAsync(Guid id, Guid tenantCode, long newVersion)
+    {
+        await using var connection = new NpgsqlConnection(GetAdminConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            "UPDATE test_entities SET entity_version = @newVersion WHERE id = @id AND tenant_code = @tenantCode",
+            connection);
+
+        command.Parameters.AddWithValue("id", id);
+        command.Parameters.AddWithValue("tenantCode", tenantCode);
+        command.Parameters.AddWithValue("newVersion", newVersion);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
     /// <inheritdoc />
     protected override void ConfigureServices(IServiceCollection services)
     {
-        // Add any services needed for tests
+        services.AddLogging();
+        services.AddSingleton<IDataModelMapper<TestEntityDataModel>, TestEntityDataModelMapper>();
     }
 
     /// <inheritdoc />

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Mappers/TestEntityDataModelMapper.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Mappers/TestEntityDataModelMapper.cs
@@ -1,0 +1,27 @@
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Mappers;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Mappers.Models;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.DataModels;
+using Npgsql;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Mappers;
+
+/// <summary>
+/// Data model mapper for TestEntityDataModel.
+/// Maps to the test_entities table in the PostgreSQL test database.
+/// </summary>
+public class TestEntityDataModelMapper : DataModelMapperBase<TestEntityDataModel>
+{
+    /// <inheritdoc />
+    protected override void ConfigureInternal(MapperOptions<TestEntityDataModel> mapperOptions)
+    {
+        mapperOptions
+            .MapTable(schema: null, name: "test_entities")
+            .MapColumn(x => x.Name);
+    }
+
+    /// <inheritdoc />
+    public override void MapBinaryImporter(NpgsqlBinaryImporter importer, TestEntityDataModel model)
+    {
+        // Not used in integration tests
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/ConnectionLifecycleIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/ConnectionLifecycleIntegrationTests.cs
@@ -1,0 +1,254 @@
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for PostgreSqlConnectionBase connection lifecycle management.
+/// </summary>
+[Collection("PostgresRepository")]
+public class ConnectionLifecycleIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public ConnectionLifecycleIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task TryOpenConnectionAsync_Should_OpenConnection()
+    {
+        // Arrange
+        LogArrange("Creating connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+
+        // Act
+        LogAct("Opening connection");
+        var result = await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying connection is open");
+        result.ShouldBeTrue();
+        connection.IsOpen().ShouldBeTrue();
+        connection.GetConnectionObject().ShouldNotBeNull();
+        LogInfo("Connection opened successfully");
+    }
+
+    [Fact]
+    public async Task TryOpenConnectionAsync_Should_BeIdempotent()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+        var firstConnectionObject = connection.GetConnectionObject();
+
+        // Act
+        LogAct("Calling TryOpenConnectionAsync again");
+        var result = await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying second call returns true and connection is still open");
+        result.ShouldBeTrue();
+        connection.IsOpen().ShouldBeTrue();
+        // Note: The double-check locking pattern returns early if already open
+        LogInfo("TryOpenConnectionAsync is idempotent");
+    }
+
+    [Fact]
+    public async Task TryCloseConnectionAsync_Should_CloseConnection()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Closing connection");
+        var result = await connection.TryCloseConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying connection is closed");
+        result.ShouldBeTrue();
+        connection.IsOpen().ShouldBeFalse();
+        connection.GetConnectionObject().ShouldBeNull();
+        LogInfo("Connection closed successfully");
+    }
+
+    [Fact]
+    public async Task TryCloseConnectionAsync_Should_BeIdempotent()
+    {
+        // Arrange
+        LogArrange("Creating, opening, and closing connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+        await connection.TryCloseConnectionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Calling TryCloseConnectionAsync again on already closed connection");
+        var result = await connection.TryCloseConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying second close returns true without error");
+        result.ShouldBeTrue();
+        connection.IsOpen().ShouldBeFalse();
+        LogInfo("TryCloseConnectionAsync is idempotent");
+    }
+
+    [Fact]
+    public void IsOpen_Should_ReturnFalse_Initially()
+    {
+        // Arrange
+        LogArrange("Creating connection without opening");
+        using var connection = _fixture.CreateAppUserConnection();
+
+        // Act
+        LogAct("Checking IsOpen");
+        var result = connection.IsOpen();
+
+        // Assert
+        LogAssert("Verifying IsOpen returns false");
+        result.ShouldBeFalse();
+        LogInfo("IsOpen correctly returns false before opening");
+    }
+
+    [Fact]
+    public void GetConnectionObject_Should_ReturnNull_BeforeOpen()
+    {
+        // Arrange
+        LogArrange("Creating connection without opening");
+        using var connection = _fixture.CreateAppUserConnection();
+
+        // Act
+        LogAct("Getting connection object");
+        var result = connection.GetConnectionObject();
+
+        // Assert
+        LogAssert("Verifying GetConnectionObject returns null");
+        result.ShouldBeNull();
+        LogInfo("GetConnectionObject correctly returns null before opening");
+    }
+
+    [Fact]
+    public async Task GetConnectionObject_Should_ReturnConnection_AfterOpen()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Getting connection object");
+        var result = connection.GetConnectionObject();
+
+        // Assert
+        LogAssert("Verifying GetConnectionObject returns NpgsqlConnection");
+        result.ShouldNotBeNull();
+        result.State.ShouldBe(System.Data.ConnectionState.Open);
+        LogInfo("GetConnectionObject correctly returns open NpgsqlConnection");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Should_CloseConnection()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+        connection.IsOpen().ShouldBeTrue();
+
+        // Act
+        LogAct("Disposing connection");
+        await connection.DisposeAsync();
+
+        // Assert
+        LogAssert("Verifying connection is closed after dispose");
+        connection.IsOpen().ShouldBeFalse();
+        connection.GetConnectionObject().ShouldBeNull();
+        LogInfo("DisposeAsync closed connection correctly");
+    }
+
+    [Fact]
+    public async Task Dispose_Should_CloseConnection()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+        connection.IsOpen().ShouldBeTrue();
+
+        // Act
+        LogAct("Disposing connection synchronously");
+        connection.Dispose();
+
+        // Assert
+        LogAssert("Verifying connection is closed after dispose");
+        connection.IsOpen().ShouldBeFalse();
+        LogInfo("Dispose closed connection correctly");
+    }
+
+    [Fact]
+    public async Task Connection_Should_ExecuteQueries_WhenOpen()
+    {
+        // Arrange
+        LogArrange("Creating and opening connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Executing query through connection");
+        using var npgsqlConnection = connection.GetConnectionObject();
+        await using var command = npgsqlConnection!.CreateCommand();
+        command.CommandText = "SELECT 1 + 1";
+        var result = await command.ExecuteScalarAsync();
+
+        // Assert
+        LogAssert("Verifying query executed successfully");
+        result.ShouldBe(2);
+        LogInfo("Query executed successfully through open connection");
+    }
+
+    [Fact]
+    public async Task IsOpen_Should_ReflectConnectionState()
+    {
+        // Arrange
+        LogArrange("Creating connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var connection = _fixture.CreateAppUserConnection();
+
+        // Assert initial state
+        connection.IsOpen().ShouldBeFalse();
+
+        // Act - Open
+        LogAct("Opening connection");
+        await connection.TryOpenConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert open state
+        LogAssert("Verifying IsOpen reflects open state");
+        connection.IsOpen().ShouldBeTrue();
+
+        // Act - Close
+        LogAct("Closing connection");
+        await connection.TryCloseConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert closed state
+        LogAssert("Verifying IsOpen reflects closed state");
+        connection.IsOpen().ShouldBeFalse();
+        LogInfo("IsOpen correctly reflects connection state transitions");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/DataModelRepositoryIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/DataModelRepositoryIntegrationTests.cs
@@ -1,0 +1,387 @@
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for DataModelRepositoryBase CRUD operations.
+/// </summary>
+[Collection("PostgresRepository")]
+public class DataModelRepositoryIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public DataModelRepositoryIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Should_ReturnEntity_WhenExists()
+    {
+        // Arrange
+        LogArrange("Creating test entity and inserting directly");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Opening connection and calling GetByIdAsync");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.GetByIdAsync(executionContext, entity.Id, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity was retrieved correctly");
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(entity.Id);
+        result.TenantCode.ShouldBe(entity.TenantCode);
+        result.Name.ShouldBe(entity.Name);
+        result.CreatedBy.ShouldBe(entity.CreatedBy);
+        result.EntityVersion.ShouldBe(entity.EntityVersion);
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("Entity retrieved successfully");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Should_ReturnNull_WhenNotExists()
+    {
+        // Arrange
+        LogArrange("Setting up context with non-existent entity ID");
+        var tenantCode = Guid.NewGuid();
+        var nonExistentId = Guid.NewGuid();
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Opening connection and calling GetByIdAsync for non-existent entity");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.GetByIdAsync(executionContext, nonExistentId, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying null is returned");
+        result.ShouldBeNull();
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("GetByIdAsync correctly returned null for non-existent entity");
+    }
+
+    [Fact]
+    public async Task ExistsAsync_Should_ReturnTrue_WhenEntityExists()
+    {
+        // Arrange
+        LogArrange("Creating and inserting test entity");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Calling ExistsAsync");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.ExistsAsync(executionContext, entity.Id, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity exists");
+        result.ShouldBeTrue();
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("ExistsAsync correctly returned true");
+    }
+
+    [Fact]
+    public async Task ExistsAsync_Should_ReturnFalse_WhenEntityNotExists()
+    {
+        // Arrange
+        LogArrange("Setting up context with non-existent entity ID");
+        var tenantCode = Guid.NewGuid();
+        var nonExistentId = Guid.NewGuid();
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Calling ExistsAsync for non-existent entity");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.ExistsAsync(executionContext, nonExistentId, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity does not exist");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("ExistsAsync correctly returned false");
+    }
+
+    [Fact]
+    public async Task InsertAsync_Should_PersistEntity()
+    {
+        // Arrange
+        LogArrange("Creating test entity for insertion");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Inserting entity via repository");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity was persisted");
+        result.ShouldBeTrue();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        persistedEntity.Id.ShouldBe(entity.Id);
+        persistedEntity.Name.ShouldBe(entity.Name);
+        LogInfo("Entity persisted successfully");
+    }
+
+    [Fact]
+    public async Task InsertAsync_Should_PopulateAllBaseFields()
+    {
+        // Arrange
+        LogArrange("Creating test entity with all fields populated");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        entity.LastChangedBy = "test_modifier";
+        entity.LastChangedAt = DateTimeOffset.UtcNow;
+        entity.LastChangedExecutionOrigin = "TestOrigin";
+        entity.LastChangedCorrelationId = Guid.NewGuid();
+        entity.LastChangedBusinessOperationCode = "TEST_OP";
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Inserting entity with all fields");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying all fields were persisted");
+        result.ShouldBeTrue();
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        persistedEntity.LastChangedBy.ShouldBe(entity.LastChangedBy);
+        persistedEntity.LastChangedExecutionOrigin.ShouldBe(entity.LastChangedExecutionOrigin);
+        persistedEntity.LastChangedCorrelationId.ShouldBe(entity.LastChangedCorrelationId);
+        persistedEntity.LastChangedBusinessOperationCode.ShouldBe(entity.LastChangedBusinessOperationCode);
+        LogInfo("All fields persisted correctly");
+    }
+
+    [Fact]
+    public async Task InsertAsync_Should_HandleNullableFields()
+    {
+        // Arrange
+        LogArrange("Creating test entity with null optional fields");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        // Leave optional fields as null
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Inserting entity with null optional fields");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying nullable fields are stored as null");
+        result.ShouldBeTrue();
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        persistedEntity.LastChangedBy.ShouldBeNull();
+        persistedEntity.LastChangedAt.ShouldBeNull();
+        persistedEntity.LastChangedExecutionOrigin.ShouldBeNull();
+        persistedEntity.LastChangedCorrelationId.ShouldBeNull();
+        persistedEntity.LastChangedBusinessOperationCode.ShouldBeNull();
+        LogInfo("Nullable fields handled correctly");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Should_ModifyEntity_WhenVersionMatches()
+    {
+        // Arrange
+        LogArrange("Creating and inserting test entity");
+        var tenantCode = Guid.NewGuid();
+        var originalVersion = 1L;
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: originalVersion);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Modify the entity - keep same version because the update uses entity_version < new_version
+        // The WHERE clause checks: entity_version < DataModel.EntityVersion
+        // So we need DataModel.EntityVersion > current DB version
+        entity.Name = "UpdatedName";
+        entity.EntityVersion = originalVersion + 1; // New version must be > current version
+
+        // Act
+        LogAct("Updating entity with matching version");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        // Note: expectedVersion parameter is used in a second WHERE clause (entity_version = expectedVersion)
+        // The full WHERE is: tenant_code AND id AND entity_version < new_version AND entity_version = expected_version
+        // For this to work: expected_version must equal current DB version AND be < new DataModel version
+        var result = await repository.UpdateAsync(executionContext, entity, expectedVersion: originalVersion, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity was updated");
+        result.ShouldBeTrue();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var updatedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        updatedEntity.ShouldNotBeNull();
+        updatedEntity.Name.ShouldBe("UpdatedName");
+        updatedEntity.EntityVersion.ShouldBe(2);
+        LogInfo("Entity updated successfully");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Should_ReturnFalse_WhenVersionMismatch()
+    {
+        // Arrange
+        LogArrange("Creating and inserting test entity with version 5");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 5);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Try to update with wrong expected version
+        entity.Name = "ShouldNotUpdate";
+        entity.EntityVersion = 6;
+
+        // Act
+        LogAct("Attempting update with stale version (expecting 1, actual is 5)");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.UpdateAsync(executionContext, entity, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying update failed due to version mismatch");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse(); // No exception, just returns false
+
+        var unchangedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        unchangedEntity.ShouldNotBeNull();
+        unchangedEntity.Name.ShouldNotBe("ShouldNotUpdate");
+        unchangedEntity.EntityVersion.ShouldBe(5); // Version unchanged
+        LogInfo("Update correctly failed due to version mismatch");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_RemoveEntity_WhenVersionMatches()
+    {
+        // Arrange
+        LogArrange("Creating and inserting test entity");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Deleting entity with matching version");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, entity.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity was deleted");
+        result.ShouldBeTrue();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var deletedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        deletedEntity.ShouldBeNull();
+        LogInfo("Entity deleted successfully");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_ReturnFalse_WhenVersionMismatch()
+    {
+        // Arrange
+        LogArrange("Creating and inserting test entity with version 3");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 3);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Attempting delete with stale version (expecting 1, actual is 3)");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, entity.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying delete failed due to version mismatch");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var stillExistsEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        stillExistsEntity.ShouldNotBeNull();
+        LogInfo("Delete correctly failed due to version mismatch");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_ReturnFalse_WhenEntityNotExists()
+    {
+        // Arrange
+        LogArrange("Setting up context with non-existent entity ID");
+        var tenantCode = Guid.NewGuid();
+        var nonExistentId = Guid.NewGuid();
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Attempting to delete non-existent entity");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, nonExistentId, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying delete returned false for non-existent entity");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("Delete correctly returned false for non-existent entity");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/HandlerPatternIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/HandlerPatternIntegrationTests.cs
@@ -1,0 +1,394 @@
+using Bedrock.BuildingBlocks.Core.Paginations;
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.DataModels;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for the handler pattern used in enumeration methods.
+/// </summary>
+[Collection("PostgresRepository")]
+public class HandlerPatternIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public HandlerPatternIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_Should_CallHandler_ForEachEntity()
+    {
+        // Arrange
+        LogArrange("Creating 3 test entities");
+        var tenantCode = Guid.NewGuid();
+        var entities = new List<TestEntityDataModel>
+        {
+            _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity1"),
+            _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity2"),
+            _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity3")
+        };
+
+        foreach (var entity in entities)
+        {
+            await _fixture.InsertTestEntityDirectlyAsync(entity);
+        }
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var handlerCallCount = 0;
+        var enumeratedIds = new List<Guid>();
+
+        // Act
+        LogAct("Enumerating all entities");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateAllAsync(
+            executionContext,
+            PaginationInfo.Create(page: 1, pageSize: 100),
+            (entity, ct) =>
+            {
+                handlerCallCount++;
+                enumeratedIds.Add(entity.Id);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying handler was called for each entity");
+        result.ShouldBeTrue();
+        handlerCallCount.ShouldBe(3);
+        foreach (var entity in entities)
+        {
+            enumeratedIds.ShouldContain(entity.Id);
+        }
+        LogInfo($"Handler called {handlerCallCount} times for {entities.Count} entities");
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_Should_StopIteration_WhenHandlerReturnsFalse()
+    {
+        // Arrange
+        LogArrange("Creating 5 test entities");
+        var tenantCode = Guid.NewGuid();
+        for (int i = 0; i < 5; i++)
+        {
+            var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: $"Entity{i}");
+            await _fixture.InsertTestEntityDirectlyAsync(entity);
+        }
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var handlerCallCount = 0;
+
+        // Act
+        LogAct("Enumerating with handler that stops after 2 entities");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateAllAsync(
+            executionContext,
+            PaginationInfo.Create(page: 1, pageSize: 100),
+            (entity, ct) =>
+            {
+                handlerCallCount++;
+                return Task.FromResult(handlerCallCount < 2); // Stop after 2nd call
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying iteration stopped after handler returned false");
+        result.ShouldBeTrue();
+        handlerCallCount.ShouldBe(2); // Handler called exactly 2 times
+        LogInfo($"Iteration correctly stopped after {handlerCallCount} calls");
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_Should_ApplyPagination()
+    {
+        // Arrange
+        LogArrange("Creating 10 test entities");
+        var tenantCode = Guid.NewGuid();
+        for (int i = 0; i < 10; i++)
+        {
+            var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: $"Entity{i:D2}");
+            await _fixture.InsertTestEntityDirectlyAsync(entity);
+        }
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var page1Entities = new List<Guid>();
+        var page2Entities = new List<Guid>();
+
+        // Act
+        LogAct("Enumerating page 1 (3 items)");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await repository.EnumerateAllAsync(
+            executionContext,
+            PaginationInfo.Create(page: 1, pageSize: 3),
+            (entity, ct) =>
+            {
+                page1Entities.Add(entity.Id);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        LogAct("Enumerating page 2 (3 items)");
+        await repository.EnumerateAllAsync(
+            executionContext,
+            PaginationInfo.Create(page: 2, pageSize: 3),
+            (entity, ct) =>
+            {
+                page2Entities.Add(entity.Id);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying pagination applied correctly");
+        page1Entities.Count.ShouldBe(3);
+        page2Entities.Count.ShouldBe(3);
+
+        // Pages should have different entities
+        foreach (var id in page1Entities)
+        {
+            page2Entities.ShouldNotContain(id);
+        }
+        LogInfo("Pagination applied correctly: Page 1 and Page 2 have different entities");
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_Should_ReturnTrue_OnEmptyResult()
+    {
+        // Arrange
+        LogArrange("Setting up context with no entities");
+        var tenantCode = Guid.NewGuid();
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var handlerCallCount = 0;
+
+        // Act
+        LogAct("Enumerating entities for empty tenant");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateAllAsync(
+            executionContext,
+            PaginationInfo.Create(page: 1, pageSize: 100),
+            (entity, ct) =>
+            {
+                handlerCallCount++;
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying returns true with zero handler calls");
+        result.ShouldBeTrue();
+        handlerCallCount.ShouldBe(0);
+        executionContext.HasExceptions.ShouldBeFalse();
+        LogInfo("Empty enumeration handled correctly");
+    }
+
+    [Fact]
+    public async Task EnumerateModifiedSinceAsync_Should_FilterByTimestamp()
+    {
+        // Arrange
+        LogArrange("Creating entities with different LastChangedAt timestamps");
+        var tenantCode = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow;
+
+        var oldEntity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "OldEntity");
+        oldEntity.LastChangedAt = baseTime.AddDays(-10);
+        oldEntity.LastChangedBy = "modifier";
+
+        var recentEntity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "RecentEntity");
+        recentEntity.LastChangedAt = baseTime.AddDays(-1);
+        recentEntity.LastChangedBy = "modifier";
+
+        var veryRecentEntity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "VeryRecentEntity");
+        veryRecentEntity.LastChangedAt = baseTime;
+        veryRecentEntity.LastChangedBy = "modifier";
+
+        await _fixture.InsertTestEntityDirectlyAsync(oldEntity);
+        await _fixture.InsertTestEntityDirectlyAsync(recentEntity);
+        await _fixture.InsertTestEntityDirectlyAsync(veryRecentEntity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var enumeratedEntities = new List<string>();
+
+        // Act
+        LogAct("Enumerating entities modified since 5 days ago");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateModifiedSinceAsync(
+            executionContext,
+            since: baseTime.AddDays(-5),
+            (entity, ct) =>
+            {
+                enumeratedEntities.Add(entity.Name);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying only recent entities were enumerated");
+        result.ShouldBeTrue();
+        enumeratedEntities.Count.ShouldBe(2);
+        enumeratedEntities.ShouldContain("RecentEntity");
+        enumeratedEntities.ShouldContain("VeryRecentEntity");
+        enumeratedEntities.ShouldNotContain("OldEntity");
+        LogInfo("Timestamp filter applied correctly");
+    }
+
+    [Fact]
+    public async Task EnumerateModifiedSinceAsync_Should_OrderByLastChangedAt()
+    {
+        // Arrange
+        LogArrange("Creating entities with specific LastChangedAt order");
+        var tenantCode = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow;
+
+        var entity1 = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity1");
+        entity1.LastChangedAt = baseTime.AddHours(-3);
+        entity1.LastChangedBy = "modifier";
+
+        var entity2 = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity2");
+        entity2.LastChangedAt = baseTime.AddHours(-1);
+        entity2.LastChangedBy = "modifier";
+
+        var entity3 = _fixture.CreateTestEntity(tenantCode: tenantCode, name: "Entity3");
+        entity3.LastChangedAt = baseTime.AddHours(-2);
+        entity3.LastChangedBy = "modifier";
+
+        // Insert in random order
+        await _fixture.InsertTestEntityDirectlyAsync(entity2);
+        await _fixture.InsertTestEntityDirectlyAsync(entity1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity3);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var enumeratedNames = new List<string>();
+
+        // Act
+        LogAct("Enumerating entities modified since 4 hours ago");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateModifiedSinceAsync(
+            executionContext,
+            since: baseTime.AddHours(-4),
+            (entity, ct) =>
+            {
+                enumeratedNames.Add(entity.Name);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entities are in ascending order by LastChangedAt");
+        result.ShouldBeTrue();
+        enumeratedNames.Count.ShouldBe(3);
+        enumeratedNames[0].ShouldBe("Entity1"); // -3 hours
+        enumeratedNames[1].ShouldBe("Entity3"); // -2 hours
+        enumeratedNames[2].ShouldBe("Entity2"); // -1 hour
+        LogInfo("Entities enumerated in correct order by LastChangedAt");
+    }
+
+    [Fact]
+    public async Task EnumerateModifiedSinceAsync_Should_StopIteration_WhenHandlerReturnsFalse()
+    {
+        // Arrange
+        LogArrange("Creating 5 entities with recent LastChangedAt");
+        var tenantCode = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow;
+
+        for (int i = 0; i < 5; i++)
+        {
+            var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, name: $"Entity{i}");
+            entity.LastChangedAt = baseTime.AddMinutes(-i);
+            entity.LastChangedBy = "modifier";
+            await _fixture.InsertTestEntityDirectlyAsync(entity);
+        }
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var handlerCallCount = 0;
+
+        // Act
+        LogAct("Enumerating with handler that stops after 3 entities");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await repository.EnumerateModifiedSinceAsync(
+            executionContext,
+            since: baseTime.AddHours(-1),
+            (entity, ct) =>
+            {
+                handlerCallCount++;
+                return Task.FromResult(handlerCallCount < 3);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying iteration stopped after handler returned false");
+        result.ShouldBeTrue();
+        handlerCallCount.ShouldBe(3);
+        LogInfo($"Iteration correctly stopped after {handlerCallCount} calls");
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_Should_FilterByTenantCode()
+    {
+        // Arrange
+        LogArrange("Creating entities for different tenants");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+
+        var entityA = _fixture.CreateTestEntity(tenantCode: tenantCodeA, name: "TenantAEntity");
+        var entityB = _fixture.CreateTestEntity(tenantCode: tenantCodeB, name: "TenantBEntity");
+
+        await _fixture.InsertTestEntityDirectlyAsync(entityA);
+        await _fixture.InsertTestEntityDirectlyAsync(entityB);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var enumeratedNames = new List<string>();
+
+        // Act
+        LogAct("Tenant A enumerates entities");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.EnumerateAllAsync(
+            executionContextA,
+            PaginationInfo.Create(page: 1, pageSize: 100),
+            (entity, ct) =>
+            {
+                enumeratedNames.Add(entity.Name);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying only Tenant A's entities were enumerated");
+        result.ShouldBeTrue();
+        enumeratedNames.Count.ShouldBe(1);
+        enumeratedNames.ShouldContain("TenantAEntity");
+        enumeratedNames.ShouldNotContain("TenantBEntity");
+        LogInfo("TenantCode filter applied correctly in enumeration");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/MultiTenancyIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/MultiTenancyIntegrationTests.cs
@@ -1,0 +1,219 @@
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for multi-tenancy isolation via TenantCode filtering.
+/// </summary>
+[Collection("PostgresRepository")]
+public class MultiTenancyIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public MultiTenancyIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_TenantA_CannotSeeTenantB_Entities()
+    {
+        // Arrange
+        LogArrange("Creating entity for Tenant B");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+        var entityB = _fixture.CreateTestEntity(tenantCode: tenantCodeB, name: "TenantBEntity");
+        await _fixture.InsertTestEntityDirectlyAsync(entityB);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Tenant A tries to read Tenant B's entity by ID");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.GetByIdAsync(executionContextA, entityB.Id, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying Tenant A cannot see Tenant B's entity");
+        result.ShouldBeNull();
+        executionContextA.HasExceptions.ShouldBeFalse();
+        LogInfo("Multi-tenancy isolation verified: Tenant A cannot see Tenant B's entity");
+    }
+
+    [Fact]
+    public async Task ExistsAsync_TenantA_CannotSeeTenantB_Entities()
+    {
+        // Arrange
+        LogArrange("Creating entity for Tenant B");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+        var entityB = _fixture.CreateTestEntity(tenantCode: tenantCodeB);
+        await _fixture.InsertTestEntityDirectlyAsync(entityB);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Tenant A checks if Tenant B's entity exists");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.ExistsAsync(executionContextA, entityB.Id, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying Tenant A sees entity as non-existent");
+        result.ShouldBeFalse();
+        executionContextA.HasExceptions.ShouldBeFalse();
+        LogInfo("Multi-tenancy isolation verified: ExistsAsync returns false for other tenant's entity");
+    }
+
+    [Fact]
+    public async Task EnumerateAllAsync_OnlyReturnsCurrentTenantEntities()
+    {
+        // Arrange
+        LogArrange("Creating entities for Tenant A and Tenant B");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+
+        var entityA1 = _fixture.CreateTestEntity(tenantCode: tenantCodeA, name: "TenantA_Entity1");
+        var entityA2 = _fixture.CreateTestEntity(tenantCode: tenantCodeA, name: "TenantA_Entity2");
+        var entityB1 = _fixture.CreateTestEntity(tenantCode: tenantCodeB, name: "TenantB_Entity1");
+
+        await _fixture.InsertTestEntityDirectlyAsync(entityA1);
+        await _fixture.InsertTestEntityDirectlyAsync(entityA2);
+        await _fixture.InsertTestEntityDirectlyAsync(entityB1);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var enumeratedEntities = new List<Guid>();
+
+        // Act
+        LogAct("Tenant A enumerates all entities");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.EnumerateAllAsync(
+            executionContextA,
+            Bedrock.BuildingBlocks.Core.Paginations.PaginationInfo.Create(page: 1, pageSize: 100),
+            (entity, ct) =>
+            {
+                enumeratedEntities.Add(entity.Id);
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying only Tenant A's entities were enumerated");
+        result.ShouldBeTrue();
+        enumeratedEntities.Count.ShouldBe(2);
+        enumeratedEntities.ShouldContain(entityA1.Id);
+        enumeratedEntities.ShouldContain(entityA2.Id);
+        enumeratedEntities.ShouldNotContain(entityB1.Id);
+        LogInfo("Multi-tenancy isolation verified: EnumerateAllAsync only returns current tenant's entities");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_TenantA_CannotModifyTenantB_Entities()
+    {
+        // Arrange
+        LogArrange("Creating entity for Tenant B");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+        var entityB = _fixture.CreateTestEntity(tenantCode: tenantCodeB, name: "OriginalName", entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entityB);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Prepare modified entity (trying to update Tenant B's entity as Tenant A)
+        var modifiedEntity = _fixture.CreateTestEntity(
+            id: entityB.Id,
+            tenantCode: tenantCodeA, // Tenant A's context has TenantCodeA
+            name: "ModifiedByTenantA",
+            entityVersion: 2);
+        modifiedEntity.CreatedBy = entityB.CreatedBy;
+        modifiedEntity.CreatedAt = entityB.CreatedAt;
+
+        // Act
+        LogAct("Tenant A tries to update Tenant B's entity");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.UpdateAsync(executionContextA, modifiedEntity, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContextA, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying Tenant A cannot modify Tenant B's entity");
+        result.ShouldBeFalse(); // No rows affected because WHERE clause includes TenantCode from ExecutionContext
+
+        var unchangedEntity = await _fixture.GetTestEntityDirectlyAsync(entityB.Id, tenantCodeB);
+        unchangedEntity.ShouldNotBeNull();
+        unchangedEntity.Name.ShouldBe("OriginalName");
+        LogInfo("Multi-tenancy isolation verified: Tenant A cannot modify Tenant B's entity");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_TenantA_CannotDeleteTenantB_Entities()
+    {
+        // Arrange
+        LogArrange("Creating entity for Tenant B");
+        var tenantCodeA = Guid.NewGuid();
+        var tenantCodeB = Guid.NewGuid();
+        var entityB = _fixture.CreateTestEntity(tenantCode: tenantCodeB, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entityB);
+
+        var executionContextA = _fixture.CreateExecutionContext(tenantCodeA);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Tenant A tries to delete Tenant B's entity");
+        await unitOfWork.OpenConnectionAsync(executionContextA, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContextA, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContextA, entityB.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContextA, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying Tenant A cannot delete Tenant B's entity");
+        result.ShouldBeFalse(); // No rows affected because WHERE clause includes TenantCode
+
+        var stillExistsEntity = await _fixture.GetTestEntityDirectlyAsync(entityB.Id, tenantCodeB);
+        stillExistsEntity.ShouldNotBeNull();
+        LogInfo("Multi-tenancy isolation verified: Tenant A cannot delete Tenant B's entity");
+    }
+
+    [Fact]
+    public async Task InsertAsync_Should_UseExecutionContextTenantCode()
+    {
+        // Arrange
+        LogArrange("Creating entity and setting ExecutionContext with specific TenantCode");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Inserting entity");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying entity was stored with correct TenantCode");
+        result.ShouldBeTrue();
+
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        persistedEntity.TenantCode.ShouldBe(tenantCode);
+        LogInfo("Entity stored with correct TenantCode from DataModel");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/OptimisticConcurrencyIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/OptimisticConcurrencyIntegrationTests.cs
@@ -1,0 +1,250 @@
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for optimistic concurrency control via EntityVersion.
+/// </summary>
+[Collection("PostgresRepository")]
+public class OptimisticConcurrencyIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public OptimisticConcurrencyIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Should_Succeed_WithMatchingVersion()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 1");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        entity.Name = "UpdatedName";
+        entity.EntityVersion = 2;
+
+        // Act
+        LogAct("Updating with expected version 1");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.UpdateAsync(executionContext, entity, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying update succeeded");
+        result.ShouldBeTrue();
+
+        var updatedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        updatedEntity.ShouldNotBeNull();
+        updatedEntity.Name.ShouldBe("UpdatedName");
+        updatedEntity.EntityVersion.ShouldBe(2);
+        LogInfo("Update with matching version succeeded");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Should_Fail_WithStaleVersion()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 10");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 10);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        var originalName = entity.Name;
+        entity.Name = "ShouldNotUpdate";
+        entity.EntityVersion = 11;
+
+        // Act
+        LogAct("Attempting update with stale version (expecting 5, actual is 10)");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.UpdateAsync(executionContext, entity, expectedVersion: 5, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying update failed (no rows affected)");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var unchangedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        unchangedEntity.ShouldNotBeNull();
+        unchangedEntity.Name.ShouldBe(originalName);
+        unchangedEntity.EntityVersion.ShouldBe(10);
+        LogInfo("Update with stale version correctly failed");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ConcurrentUpdates_FirstWinsSecondFails()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 1");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext1 = _fixture.CreateExecutionContext(tenantCode);
+        var executionContext2 = _fixture.CreateExecutionContext(tenantCode);
+
+        // Simulate first "user" reading and updating
+        await using var unitOfWork1 = _fixture.CreateAppUserUnitOfWork();
+        var repository1 = _fixture.CreateRepository(unitOfWork1);
+
+        // Simulate second "user" reading and updating
+        await using var unitOfWork2 = _fixture.CreateAppUserUnitOfWork();
+        var repository2 = _fixture.CreateRepository(unitOfWork2);
+
+        // Act
+        LogAct("First user updates the entity");
+        await unitOfWork1.OpenConnectionAsync(executionContext1, CancellationToken.None);
+        await unitOfWork1.BeginTransactionAsync(executionContext1, CancellationToken.None);
+
+        var entity1 = _fixture.CreateTestEntity(
+            id: entity.Id,
+            tenantCode: tenantCode,
+            name: "FirstUserUpdate",
+            entityVersion: 2);
+        entity1.CreatedBy = entity.CreatedBy;
+        entity1.CreatedAt = entity.CreatedAt;
+
+        var result1 = await repository1.UpdateAsync(executionContext1, entity1, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork1.CommitAsync(executionContext1, CancellationToken.None);
+
+        LogAct("Second user tries to update with same original version");
+        await unitOfWork2.OpenConnectionAsync(executionContext2, CancellationToken.None);
+        await unitOfWork2.BeginTransactionAsync(executionContext2, CancellationToken.None);
+
+        var entity2 = _fixture.CreateTestEntity(
+            id: entity.Id,
+            tenantCode: tenantCode,
+            name: "SecondUserUpdate",
+            entityVersion: 2);
+        entity2.CreatedBy = entity.CreatedBy;
+        entity2.CreatedAt = entity.CreatedAt;
+
+        var result2 = await repository2.UpdateAsync(executionContext2, entity2, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork2.CommitAsync(executionContext2, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying first update succeeded and second failed");
+        result1.ShouldBeTrue();
+        result2.ShouldBeFalse();
+
+        var finalEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        finalEntity.ShouldNotBeNull();
+        finalEntity.Name.ShouldBe("FirstUserUpdate");
+        finalEntity.EntityVersion.ShouldBe(2);
+        LogInfo("Concurrent update scenario handled correctly - first wins");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_Succeed_WithMatchingVersion()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 1");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Deleting with expected version 1");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, entity.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying delete succeeded");
+        result.ShouldBeTrue();
+
+        var deletedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        deletedEntity.ShouldBeNull();
+        LogInfo("Delete with matching version succeeded");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_Fail_WithStaleVersion()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 5");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 5);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Attempting delete with stale version (expecting 1, actual is 5)");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, entity.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying delete failed (no rows affected)");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var stillExistsEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        stillExistsEntity.ShouldNotBeNull();
+        LogInfo("Delete with stale version correctly failed");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_Fail_WhenConcurrentUpdateOccurs()
+    {
+        // Arrange
+        LogArrange("Creating entity with version 1");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode, entityVersion: 1);
+        await _fixture.InsertTestEntityDirectlyAsync(entity);
+
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Simulate concurrent update by another process
+        LogAct("Another process updates entity to version 2");
+        await _fixture.UpdateEntityVersionDirectlyAsync(entity.Id, tenantCode, 2);
+
+        // Now try to delete with stale version
+        LogAct("Attempting delete with original version 1");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var result = await repository.DeleteAsync(executionContext, entity.Id, expectedVersion: 1, CancellationToken.None);
+        await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying delete failed due to concurrent update");
+        result.ShouldBeFalse();
+
+        var stillExistsEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        stillExistsEntity.ShouldNotBeNull();
+        stillExistsEntity.EntityVersion.ShouldBe(2);
+        LogInfo("Delete correctly failed after concurrent update");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/TestEntityRepository.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/TestEntityRepository.cs
@@ -1,0 +1,28 @@
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.DataModelRepositories;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Mappers.Interfaces;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.UnitOfWork.Interfaces;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.DataModels;
+using Microsoft.Extensions.Logging;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Test entity repository for integration tests.
+/// Extends DataModelRepositoryBase to test the base repository functionality.
+/// </summary>
+public class TestEntityRepository : DataModelRepositoryBase<TestEntityDataModel>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestEntityRepository"/> class.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="unitOfWork">The unit of work for managing database connections and transactions.</param>
+    /// <param name="mapper">The data model mapper for SQL generation and property mapping.</param>
+    public TestEntityRepository(
+        ILogger<TestEntityRepository> logger,
+        IPostgreSqlUnitOfWork unitOfWork,
+        IDataModelMapper<TestEntityDataModel> mapper)
+        : base(logger, unitOfWork, mapper)
+    {
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/UnitOfWorkIntegrationTests.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/Repositories/UnitOfWorkIntegrationTests.cs
@@ -1,0 +1,286 @@
+using Bedrock.BuildingBlocks.Testing.Integration;
+using Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Fixtures;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.Repositories;
+
+/// <summary>
+/// Integration tests for PostgreSqlUnitOfWorkBase transaction management.
+/// </summary>
+[Collection("PostgresRepository")]
+public class UnitOfWorkIntegrationTests : IntegrationTestBase
+{
+    private readonly PostgresRepositoryFixture _fixture;
+
+    public UnitOfWorkIntegrationTests(
+        PostgresRepositoryFixture fixture,
+        ITestOutputHelper output)
+        : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_CommitTransaction_OnSuccess()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork and Repository");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Executing handler that returns true (success)");
+        var result = await unitOfWork.ExecuteAsync(
+            executionContext,
+            entity,
+            async (ctx, ent, ct) =>
+            {
+                var insertResult = await repository.InsertAsync(ctx, ent, ct);
+                return insertResult;
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying transaction was committed and data persisted");
+        result.ShouldBeTrue();
+        executionContext.HasExceptions.ShouldBeFalse();
+
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        persistedEntity.Name.ShouldBe(entity.Name);
+        LogInfo("Transaction committed successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_RollbackTransaction_OnHandlerFailure()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork and Repository");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Executing handler that returns false (failure)");
+        var result = await unitOfWork.ExecuteAsync(
+            executionContext,
+            entity,
+            async (ctx, ent, ct) =>
+            {
+                await repository.InsertAsync(ctx, ent, ct);
+                return false; // Simulate failure
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying transaction was rolled back and data not persisted");
+        result.ShouldBeFalse();
+
+        var notPersistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        notPersistedEntity.ShouldBeNull();
+        LogInfo("Transaction rolled back correctly on handler failure");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_RollbackTransaction_OnException()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork and Repository");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        // Act
+        LogAct("Executing handler that throws exception");
+        var result = await unitOfWork.ExecuteAsync(
+            executionContext,
+            entity,
+            async (ctx, ent, ct) =>
+            {
+                await repository.InsertAsync(ctx, ent, ct);
+                throw new InvalidOperationException("Test exception");
+            },
+            CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying transaction was rolled back, exception logged, and data not persisted");
+        result.ShouldBeFalse();
+        executionContext.HasExceptions.ShouldBeTrue();
+
+        var notPersistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        notPersistedEntity.ShouldBeNull();
+        LogInfo("Transaction rolled back correctly on exception");
+    }
+
+    [Fact]
+    public async Task BeginTransactionAsync_Should_CreateTransaction()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+
+        // Act
+        LogAct("Opening connection and beginning transaction");
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        var result = await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying transaction was created");
+        result.ShouldBeTrue();
+        unitOfWork.GetCurrentTransaction().ShouldNotBeNull();
+        LogInfo("Transaction created successfully");
+    }
+
+    [Fact]
+    public async Task BeginTransactionAsync_Should_BeIdempotent()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork with open connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        var firstTransaction = unitOfWork.GetCurrentTransaction();
+
+        // Act
+        LogAct("Calling BeginTransactionAsync again");
+        var result = await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying second call returns true and same transaction");
+        result.ShouldBeTrue();
+        unitOfWork.GetCurrentTransaction().ShouldBe(firstTransaction);
+        LogInfo("BeginTransactionAsync is idempotent");
+    }
+
+    [Fact]
+    public async Task CommitAsync_Should_PersistChanges()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork, Repository and inserting entity");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+
+        // Act
+        LogAct("Committing transaction");
+        var result = await unitOfWork.CommitAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying changes were persisted after commit");
+        result.ShouldBeTrue();
+
+        var persistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        persistedEntity.ShouldNotBeNull();
+        LogInfo("Commit persisted changes successfully");
+    }
+
+    [Fact]
+    public async Task RollbackAsync_Should_DiscardChanges()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork, Repository and inserting entity");
+        var tenantCode = Guid.NewGuid();
+        var entity = _fixture.CreateTestEntity(tenantCode: tenantCode);
+        var executionContext = _fixture.CreateExecutionContext(tenantCode);
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        var repository = _fixture.CreateRepository(unitOfWork);
+
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+        await repository.InsertAsync(executionContext, entity, CancellationToken.None);
+
+        // Act
+        LogAct("Rolling back transaction");
+        var result = await unitOfWork.RollbackAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying changes were discarded after rollback");
+        result.ShouldBeTrue();
+
+        var notPersistedEntity = await _fixture.GetTestEntityDirectlyAsync(entity.Id, tenantCode);
+        notPersistedEntity.ShouldBeNull();
+        LogInfo("Rollback discarded changes successfully");
+    }
+
+    [Fact]
+    public async Task CreateNpgsqlCommand_Should_AttachConnectionAndTransaction()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork with connection and transaction");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Creating NpgsqlCommand");
+        using var command = unitOfWork.CreateNpgsqlCommand("SELECT 1");
+
+        // Assert
+        LogAssert("Verifying command has connection and transaction attached");
+        command.ShouldNotBeNull();
+        command.Connection.ShouldBe(unitOfWork.GetCurrentConnection());
+        command.Transaction.ShouldBe(unitOfWork.GetCurrentTransaction());
+        LogInfo("Command created with correct connection and transaction");
+    }
+
+    [Fact]
+    public async Task CloseConnectionAsync_Should_CloseAndDisposeTransaction()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork with open connection and transaction");
+        var executionContext = _fixture.CreateExecutionContext();
+        await using var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Closing connection");
+        var result = await unitOfWork.CloseConnectionAsync(executionContext, CancellationToken.None);
+
+        // Assert
+        LogAssert("Verifying connection is closed and transaction disposed");
+        result.ShouldBeTrue();
+        unitOfWork.GetCurrentTransaction().ShouldBeNull();
+        unitOfWork.GetCurrentConnection().ShouldBeNull();
+        LogInfo("Connection closed and transaction disposed correctly");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Should_CleanupResources()
+    {
+        // Arrange
+        LogArrange("Setting up UnitOfWork with open connection");
+        var executionContext = _fixture.CreateExecutionContext();
+        var unitOfWork = _fixture.CreateAppUserUnitOfWork();
+        await unitOfWork.OpenConnectionAsync(executionContext, CancellationToken.None);
+        await unitOfWork.BeginTransactionAsync(executionContext, CancellationToken.None);
+
+        // Act
+        LogAct("Disposing UnitOfWork");
+        await unitOfWork.DisposeAsync();
+
+        // Assert
+        LogAssert("Verifying resources are cleaned up");
+        unitOfWork.GetCurrentTransaction().ShouldBeNull();
+        unitOfWork.GetCurrentConnection().ShouldBeNull();
+        LogInfo("DisposeAsync cleaned up resources correctly");
+    }
+}

--- a/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/UnitOfWork/TestPostgreSqlUnitOfWork.cs
+++ b/tests/IntegrationTests/BuildingBlocks/Persistence.PostgreSql/UnitOfWork/TestPostgreSqlUnitOfWork.cs
@@ -1,0 +1,23 @@
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.Connections.Interfaces;
+using Bedrock.BuildingBlocks.Persistence.PostgreSql.UnitOfWork;
+using Microsoft.Extensions.Logging;
+
+namespace Bedrock.IntegrationTests.BuildingBlocks.Persistence.PostgreSql.UnitOfWork;
+
+/// <summary>
+/// Test PostgreSQL unit of work implementation for integration tests.
+/// </summary>
+public class TestPostgreSqlUnitOfWork : PostgreSqlUnitOfWorkBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestPostgreSqlUnitOfWork"/> class.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="connection">The PostgreSQL connection.</param>
+    public TestPostgreSqlUnitOfWork(
+        ILogger<TestPostgreSqlUnitOfWork> logger,
+        IPostgreSqlConnection connection)
+        : base(logger, "TestUnitOfWork", connection)
+    {
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Persistence.PostgreSql/Mappers/DataModelMapperBaseTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Persistence.PostgreSql/Mappers/DataModelMapperBaseTests.cs
@@ -438,6 +438,66 @@ public class DataModelMapperBaseTests : TestBase
     }
 
     [Fact]
+    public void WhereWithParameterSuffix_WithPropertyName_ShouldReturnWhereClauseWithSuffix()
+    {
+        // Act
+        LogAct("Creating where clause with parameter suffix");
+        WhereClause whereClause = _mapper.WhereWithParameterSuffix("CustomField", "_expected", RelationalOperator.Equal);
+
+        // Assert
+        LogAssert("Verifying where clause contains suffix");
+        string clause = whereClause.ToString();
+        clause.ShouldContain("custom_field =");
+        clause.ShouldContain("_expected");
+    }
+
+    [Fact]
+    public void WhereWithParameterSuffix_WithExpression_ShouldReturnWhereClauseWithSuffix()
+    {
+        // Act
+        LogAct("Creating where clause with expression and parameter suffix");
+        WhereClause whereClause = _mapper.WhereWithParameterSuffix(x => x.CustomField, "_version", RelationalOperator.GreaterThan);
+
+        // Assert
+        LogAssert("Verifying where clause contains suffix and operator");
+        string clause = whereClause.ToString();
+        clause.ShouldContain("custom_field >");
+        clause.ShouldContain("_version");
+    }
+
+    [Fact]
+    public void WhereWithParameterSuffix_WithDifferentOperators_ShouldReturnCorrectClause()
+    {
+        // Act
+        LogAct("Creating where clauses with different operators");
+        WhereClause lessThan = _mapper.WhereWithParameterSuffix("CustomField", "_lt", RelationalOperator.LessThan);
+        WhereClause greaterOrEqual = _mapper.WhereWithParameterSuffix("CustomField", "_gte", RelationalOperator.GreaterThanOrEqual);
+        WhereClause notEqual = _mapper.WhereWithParameterSuffix("CustomField", "_ne", RelationalOperator.NotEqual);
+
+        // Assert
+        LogAssert("Verifying each operator is correctly applied");
+        lessThan.ToString().ShouldContain("< @");
+        lessThan.ToString().ShouldContain("_lt");
+        greaterOrEqual.ToString().ShouldContain(">= @");
+        greaterOrEqual.ToString().ShouldContain("_gte");
+        notEqual.ToString().ShouldContain("<> @");
+        notEqual.ToString().ShouldContain("_ne");
+    }
+
+    [Fact]
+    public void WhereWithParameterSuffix_ShouldIncludeTableNameInClause()
+    {
+        // Act
+        LogAct("Creating where clause with suffix");
+        WhereClause whereClause = _mapper.WhereWithParameterSuffix(x => x.CustomField, "_test", RelationalOperator.Equal);
+
+        // Assert
+        LogAssert("Verifying table name is included in clause");
+        string clause = whereClause.ToString();
+        clause.ShouldContain("public.test_entities.custom_field");
+    }
+
+    [Fact]
     public void OrderBy_WithPropertyNameAndAscending_ShouldReturnOrderByClause()
     {
         // Act
@@ -638,15 +698,16 @@ public class DataModelMapperBaseTests : TestBase
     }
 
     [Fact]
-    public void UpdateCommand_ShouldContainBaseWhereClauseWithVersionCheck()
+    public void UpdateCommand_ShouldContainTenantAndIdInWhereClause()
     {
         // Act
         LogAct("Getting update command");
         string updateCommand = _mapper.UpdateCommand;
 
         // Assert
-        LogAssert("Verifying update command contains version check");
-        updateCommand.ShouldContain("entity_version <");
+        LogAssert("Verifying update command contains tenant and id in WHERE clause");
+        updateCommand.ShouldContain("tenant_code =");
+        updateCommand.ShouldContain("id =");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds 58 comprehensive integration tests for PostgreSQL persistence components that couldn't be unit tested (sealed Npgsql types)
- Fixes two critical bugs discovered during testing:
  - **#106**: `UpdateAsync` always failed due to parameter name conflict between SET and WHERE EntityVersion clauses
  - **#107**: `PopulateDataModelBaseFromReader` failed with "field not found" due to alias mismatch (column name vs property name)

## Test plan
- [x] Local pipeline passes (build, tests, mutation, integration)
- [x] 58 new integration tests cover: CRUD operations, transactions, optimistic concurrency, multi-tenancy isolation, handler patterns, and connection lifecycle
- [x] Existing unit tests updated for new `WhereWithParameterSuffix` methods
- [ ] GitHub Actions pipeline passes

Closes #106
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)