### PR TITLE
chore(ci): exclude benchmark infrastructure from SonarCloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
             /o:"castelobrancolab" \
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" \
-            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*" \
-            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*" \
+            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
+            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
             /d:sonar.cpd.exclusions="**/Serialization.Avro/AvroSerializerBase.cs,**/Serialization.Protobuf/ProtobufSerializerBase.cs,**/Serialization.Parquet/ParquetSerializerBase.cs"
 
       - name: Build


### PR DESCRIPTION
## Summary

- Exclude `src/BuildingBlocks/Testing/Benchmarks/**` from SonarCloud analysis and coverage — testing infrastructure tightly coupled to .NET runtime (Timer, GC, Process) that cannot be meaningfully unit tested
- Exclude `tools/**` (BenchmarkReportGenerator) — CLI tool for report generation, not business logic

## Test plan

- [ ] GitHub Actions pipeline passes
- [ ] SonarCloud quality gate passes (no longer flags benchmark infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)