### PR TITLE
feat(testing): corrigir e melhorar relatório de benchmark

### DIFF
--- a/src/BuildingBlocks/Testing/Benchmarks/NetworkEventListener.cs
+++ b/src/BuildingBlocks/Testing/Benchmarks/NetworkEventListener.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics.Tracing;
+
+namespace Bedrock.BuildingBlocks.Testing.Benchmarks;
+
+/// <summary>
+/// Listens to the <c>System.Net.Sockets</c> EventSource to capture cumulative
+/// network bytes sent and received by the current process.
+/// <para>
+/// Uses <see cref="EventListener"/> to subscribe to the <c>bytes-sent</c> and
+/// <c>bytes-received</c> <see cref="PollingCounter"/>s, which report the total
+/// accumulated bytes via the <c>Mean</c> payload field.
+/// These counters are updated by the .NET runtime for all TCP socket operations
+/// (including Npgsql, HttpClient, etc.).
+/// </para>
+/// <para>
+/// Thread-safe: values are read/written using <see cref="Interlocked"/> operations.
+/// </para>
+/// </summary>
+internal sealed class NetworkEventListener : EventListener
+{
+    private const string SocketsEventSourceName = "System.Net.Sockets";
+    private const string BytesSentCounter = "bytes-sent";
+    private const string BytesReceivedCounter = "bytes-received";
+
+    private long _bytesSent;
+    private long _bytesReceived;
+
+    /// <summary>
+    /// Gets the cumulative total of bytes sent by the process since startup.
+    /// </summary>
+    public long BytesSent => Interlocked.Read(ref _bytesSent);
+
+    /// <summary>
+    /// Gets the cumulative total of bytes received by the process since startup.
+    /// </summary>
+    public long BytesReceived => Interlocked.Read(ref _bytesReceived);
+
+    /// <inheritdoc />
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource.Name == SocketsEventSourceName)
+        {
+            EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All,
+                new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "1" });
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventName != "EventCounters" || eventData.Payload is null || eventData.Payload.Count == 0)
+            return;
+
+        if (eventData.Payload[0] is not IDictionary<string, object> payload)
+            return;
+
+        if (!payload.TryGetValue("Name", out var nameObj) || nameObj is not string name)
+            return;
+
+        // PollingCounter reports the cumulative total in "Mean" field.
+        // IncrementingEventCounter/IncrementingPollingCounter use "Increment".
+        // Try both to handle either counter type.
+        double value;
+        if (payload.TryGetValue("Mean", out var meanObj))
+            value = Convert.ToDouble(meanObj);
+        else if (payload.TryGetValue("Increment", out var incrementObj))
+            value = Convert.ToDouble(incrementObj);
+        else
+            return;
+
+        var longValue = (long)value;
+
+        if (name == BytesSentCounter)
+            Interlocked.Exchange(ref _bytesSent, longValue);
+        else if (name == BytesReceivedCounter)
+            Interlocked.Exchange(ref _bytesReceived, longValue);
+    }
+}

--- a/tools/BenchmarkReportGenerator/Program.cs
+++ b/tools/BenchmarkReportGenerator/Program.cs
@@ -243,12 +243,19 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
                 .card.pass{border-left:4px solid var(--passed)}.card.pass .card-value{color:var(--passed)}
                 .card.warn{border-left:4px solid var(--warn)}.card.warn .card-value{color:var(--warn)}
 
-                .chart-section{display:grid;grid-template-columns:2fr 1fr;gap:2rem;margin-bottom:2rem;background:var(--card);padding:1.5rem;border-radius:.75rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
+                .env-section{background:var(--card);padding:1.25rem 1.5rem;border-radius:.75rem;box-shadow:0 1px 3px rgba(0,0,0,.1);margin-bottom:2rem}
+                .env-section h3{font-size:1rem;margin-bottom:.75rem;border-bottom:1px solid var(--border);padding-bottom:.5rem}
+                .env-section dl{display:flex;flex-wrap:wrap;gap:.5rem 2rem;font-size:.875rem}
+                .env-section dt{color:var(--muted);font-size:.75rem;text-transform:uppercase}.env-section dd{font-weight:500;margin-right:1rem}
+                .chart-section{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:2rem;margin-bottom:2rem;background:var(--card);padding:1.5rem;border-radius:.75rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
                 @media(max-width:768px){.chart-section{grid-template-columns:1fr}}
                 .chart-container{position:relative;height:300px}
-                .env-info{font-size:.875rem}.env-info h3{font-size:1rem;margin-bottom:1rem;border-bottom:1px solid var(--border);padding-bottom:.5rem}
-                .env-info dl{display:grid;grid-template-columns:auto 1fr;gap:.5rem 1rem}
-                .env-info dt{color:var(--muted);font-size:.75rem;text-transform:uppercase}.env-info dd{font-weight:500}
+
+                .percentile-table{margin-bottom:0}
+                .percentile-tables{overflow-x:auto}
+                .pct-up{color:var(--warn);font-size:.7rem;font-weight:600}
+                .pct-down{color:var(--passed);font-size:.7rem;font-weight:600}
+                .pct-neutral{color:var(--muted);font-size:.7rem}
 
                 .section-header{font-size:1.25rem;font-weight:600;margin-bottom:1rem;border-bottom:2px solid var(--border);padding-bottom:.5rem}
 
@@ -314,14 +321,12 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
             </section>
         """);
 
-    // --- Chart + Environment ---
+    // --- Environment ---
     sb.Append("""
-            <section class="chart-section">
-                <div class="chart-container"><canvas id="meanChart"></canvas></div>
-                <div class="env-info">
-                    <h3>Ambiente</h3>
-                    <dl>
-                        <dt>Maquina</dt><dd>
+            <section class="env-section">
+                <h3>Ambiente</h3>
+                <dl>
+                    <dt>Maquina</dt><dd>
         """);
     sb.Append(WebUtility.HtmlEncode(Environment.MachineName));
     sb.Append("</dd><dt>SO</dt><dd>");
@@ -334,8 +339,33 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
     sb.Append(WebUtility.HtmlEncode(gitCommit.Length >= 7 ? gitCommit[..7] : gitCommit));
     sb.Append("""
                     </dd>
-                    </dl>
-                </div>
+                </dl>
+            </section>
+        """);
+
+    // --- Charts ---
+    var hasMeanTimeData = results.Any(r => r.Median > 0 || !string.IsNullOrEmpty(r.MeanTime));
+
+    sb.Append("""
+            <section class="chart-section">
+        """);
+
+    if (hasMeanTimeData)
+    {
+        sb.Append("""
+                <div class="chart-container"><canvas id="meanChart"></canvas></div>
+        """);
+    }
+    else
+    {
+        sb.Append("""
+                <div class="chart-container"><canvas id="heapChart"></canvas></div>
+                <div class="chart-container"><canvas id="cpuChart"></canvas></div>
+                <div class="chart-container"><canvas id="networkChart"></canvas></div>
+        """);
+    }
+
+    sb.Append("""
             </section>
         """);
 
@@ -348,11 +378,11 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
                         <tr>
                             <th>Status</th>
                             <th>Benchmark</th>
-                            <th class="num">Mean</th>
-                            <th class="num">Allocated</th>
-                            <th>Memory</th>
-                            <th class="num">Avg CPU</th>
-                            <th class="num">Network I/O</th>
+                            <th class="num">Tempo Medio</th>
+                            <th class="num">Alocado</th>
+                            <th>Memoria</th>
+                            <th class="num">CPU Medio</th>
+                            <th class="num">Rede I/O</th>
                             <th class="num">GC (0/1/2)</th>
                         </tr>
                     </thead>
@@ -371,7 +401,7 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
             _ => "<span>-</span>"
         };
         var networkIO = r.NetworkBytesSent > 0 || r.NetworkBytesReceived > 0
-            ? $"S:{FormatBytes(r.NetworkBytesSent)} R:{FormatBytes(r.NetworkBytesReceived)}"
+            ? $"E:{FormatBytes(r.NetworkBytesSent)} R:{FormatBytes(r.NetworkBytesReceived)}"
             : "-";
 
         sb.Append($"""
@@ -429,31 +459,70 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
                     </div>
                     <div class="detail-content">
                         <div class="metrics-grid">
-                            <div class="metric"><div class="metric-label">Mean Time</div><div class="metric-value">{WebUtility.HtmlEncode(r.MeanTime ?? "-")}</div></div>
-                            <div class="metric"><div class="metric-label">Median Time</div><div class="metric-value">{WebUtility.HtmlEncode(r.MedianTime ?? r.StdDevFormatted ?? "-")}</div></div>
-                            <div class="metric"><div class="metric-label">Allocated</div><div class="metric-value">{WebUtility.HtmlEncode(r.Allocated ?? "-")}</div></div>
-                            <div class="metric"><div class="metric-label">Memory Growth</div><div class="metric-value">{WebUtility.HtmlEncode(r.MemoryGrowth ?? "-")}</div></div>
-                            <div class="metric"><div class="metric-label">Initial Heap</div><div class="metric-value">{r.InitialHeapMb:F2} MB</div></div>
-                            <div class="metric"><div class="metric-label">Final Heap</div><div class="metric-value">{r.FinalHeapMb:F2} MB</div></div>
-                            <div class="metric"><div class="metric-label">Heap Growth</div><div class="metric-value">{r.HeapGrowthPercent:F2}%</div></div>
-                            <div class="metric"><div class="metric-label">Samples</div><div class="metric-value">{r.MemorySamples}</div></div>
-                            <div class="metric"><div class="metric-label">Avg CPU</div><div class="metric-value">{r.AvgCpuPercent:F1}%</div></div>
-                            <div class="metric"><div class="metric-label">Peak CPU</div><div class="metric-value">{r.PeakCpuPercent:F1}%</div></div>
+                            <div class="metric"><div class="metric-label">Tempo Medio</div><div class="metric-value">{WebUtility.HtmlEncode(r.MeanTime ?? "-")}</div></div>
+                            <div class="metric"><div class="metric-label">Tempo Mediano</div><div class="metric-value">{WebUtility.HtmlEncode(r.MedianTime ?? r.StdDevFormatted ?? "-")}</div></div>
+                            <div class="metric"><div class="metric-label">Alocado</div><div class="metric-value">{WebUtility.HtmlEncode(r.Allocated ?? "-")}</div></div>
+                            <div class="metric"><div class="metric-label">Crescimento Memoria</div><div class="metric-value">{WebUtility.HtmlEncode(r.MemoryGrowth ?? "-")}</div></div>
+                            <div class="metric"><div class="metric-label">Heap Inicial</div><div class="metric-value">{r.InitialHeapMb:F2} MB</div></div>
+                            <div class="metric"><div class="metric-label">Heap Final</div><div class="metric-value">{r.FinalHeapMb:F2} MB</div></div>
+                            <div class="metric"><div class="metric-label">Crescimento Heap</div><div class="metric-value">{r.HeapGrowthPercent:F2}%</div></div>
+                            <div class="metric"><div class="metric-label">Amostras</div><div class="metric-value">{r.MemorySamples}</div></div>
+                            <div class="metric"><div class="metric-label">CPU Medio</div><div class="metric-value">{r.AvgCpuPercent:F1}%</div></div>
+                            <div class="metric"><div class="metric-label">CPU Pico</div><div class="metric-value">{r.PeakCpuPercent:F1}%</div></div>
                             <div class="metric"><div class="metric-label">GC Gen0</div><div class="metric-value">{r.GcGen0}</div></div>
                             <div class="metric"><div class="metric-label">GC Gen1</div><div class="metric-value">{r.GcGen1}</div></div>
                             <div class="metric"><div class="metric-label">GC Gen2</div><div class="metric-value">{r.GcGen2}</div></div>
-                            <div class="metric"><div class="metric-label">Network Sent</div><div class="metric-value">{FormatBytes(r.NetworkBytesSent)}</div></div>
-                            <div class="metric"><div class="metric-label">Network Received</div><div class="metric-value">{FormatBytes(r.NetworkBytesReceived)}</div></div>
+                            <div class="metric"><div class="metric-label">Rede Enviado</div><div class="metric-value">{FormatBytes(r.NetworkBytesSent)}</div></div>
+                            <div class="metric"><div class="metric-label">Rede Recebido</div><div class="metric-value">{FormatBytes(r.NetworkBytesReceived)}</div></div>
                         </div>
             """);
 
         if (hasSamples)
         {
             sb.Append($"""
-                        <div class="chart-label">Timeline de Metricas</div>
+                        <div class="chart-label">Linha do Tempo de Metricas</div>
                         <div class="timeline-chart"><canvas id="{canvasId}"></canvas></div>
                         <script type="application/json" id="{canvasId}_data">{r.SamplesJson}</script>
                 """);
+
+            // Percentile table inside the detail
+            var percentiles = new[] { 25, 50, 70, 75, 90, 95, 99 };
+            var samples = ParseSamplesForPercentiles(r.SamplesJson);
+            if (samples.Count >= 2)
+            {
+                var cpuValues = samples.Select(s => s.Cpu).OrderBy(v => v).ToArray();
+                var heapValues = samples.Select(s => s.Heap).OrderBy(v => v).ToArray();
+                var ioSentDeltas = new List<double>();
+                var ioRecvDeltas = new List<double>();
+                for (var i = 1; i < samples.Count; i++)
+                {
+                    ioSentDeltas.Add((samples[i].NetS - samples[i - 1].NetS) / 1024.0);
+                    ioRecvDeltas.Add((samples[i].NetR - samples[i - 1].NetR) / 1024.0);
+                }
+                var ioSentArr = ioSentDeltas.OrderBy(v => v).ToArray();
+                var ioRecvArr = ioRecvDeltas.OrderBy(v => v).ToArray();
+
+                sb.Append("""
+                        <div class="chart-label" style="margin-top:1.5rem">Estatisticas e Percentis</div>
+                        <div class="percentile-tables">
+                            <table class="bench-table percentile-table">
+                                <thead><tr><th>Metrica</th><th class="num">Min</th><th class="num">Media</th><th class="num">Max</th><th class="num">Desvio Padrao</th>
+                """);
+                foreach (var p in percentiles)
+                    sb.Append(CultureInfo.InvariantCulture, $"<th class=\"num\">P{p}</th>");
+                sb.Append("</tr></thead><tbody>");
+
+                AppendStatsRow(sb, "CPU (%)", cpuValues, percentiles, "F1");
+                AppendStatsRow(sb, "Heap GC (MB)", heapValues, percentiles, "F2");
+                AppendStatsRow(sb, "Rede Enviado (KB/s)", ioSentArr, percentiles, "F1");
+                AppendStatsRow(sb, "Rede Recebido (KB/s)", ioRecvArr, percentiles, "F1");
+
+                sb.Append("""
+                                </tbody>
+                            </table>
+                        </div>
+                """);
+            }
         }
 
         sb.Append("""
@@ -480,33 +549,71 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
         <script>
         """);
 
-    // Build chart data - bar chart of mean times
+    // Build chart data
     var chartLabels = new StringBuilder();
-    var chartData = new StringBuilder();
-    var chartColors = new StringBuilder();
     var first = true;
     foreach (var r in results)
     {
-        if (!first) { chartLabels.Append(','); chartData.Append(','); chartColors.Append(','); }
+        if (!first) chartLabels.Append(',');
         first = false;
-
         var shortName = r.Name.Contains('.') ? r.Name[(r.Name.LastIndexOf('.') + 1)..] : r.Name;
         chartLabels.Append(CultureInfo.InvariantCulture, $"'{EscapeJs(shortName)}'");
-
-        // Parse mean time back to number for chart (use raw nanoseconds if available)
-        var meanVal = r.Median > 0 ? r.Median / 1_000_000.0 : ParseTimeToMs(r.MeanTime ?? "0");
-        chartData.Append(CultureInfo.InvariantCulture, $"{meanVal:F3}");
-        chartColors.Append(r.Status == "WARN" ? "'#f59e0b'" : "'#10b981'");
     }
 
-    sb.Append(CultureInfo.InvariantCulture, $@"
-        var meanChart=new Chart(document.getElementById('meanChart'),{{type:'bar',data:{{labels:[{chartLabels}],datasets:[{{label:'Mean Time (ms)',data:[{chartData}],backgroundColor:[{chartColors}],borderWidth:0,borderRadius:4}}]}},options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}},title:{{display:true,text:'Tempo Medio por Benchmark (ms)',color:getComputedStyle(document.body).getPropertyValue('--text').trim()}}}},scales:{{y:{{beginAtZero:true,grid:{{color:'rgba(148,163,184,0.1)'}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}},x:{{grid:{{display:false}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxRotation:45}}}}}}}}}});");
+    if (hasMeanTimeData)
+    {
+        var chartData = new StringBuilder();
+        var chartColors = new StringBuilder();
+        first = true;
+        foreach (var r in results)
+        {
+            if (!first) { chartData.Append(','); chartColors.Append(','); }
+            first = false;
+            var meanVal = r.Median > 0 ? r.Median / 1_000_000.0 : ParseTimeToMs(r.MeanTime ?? "0");
+            chartData.Append(CultureInfo.InvariantCulture, $"{meanVal:F3}");
+            chartColors.Append(r.Status == "WARN" ? "'#f59e0b'" : "'#10b981'");
+        }
+
+        sb.Append(CultureInfo.InvariantCulture, $@"
+        var meanChart=new Chart(document.getElementById('meanChart'),{{type:'bar',data:{{labels:[{chartLabels}],datasets:[{{label:'Tempo Medio (ms)',data:[{chartData}],backgroundColor:[{chartColors}],borderWidth:0,borderRadius:4}}]}},options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}},title:{{display:true,text:'Tempo Medio por Benchmark (ms)',color:getComputedStyle(document.body).getPropertyValue('--text').trim()}}}},scales:{{y:{{beginAtZero:true,grid:{{color:'rgba(148,163,184,0.1)'}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}},x:{{grid:{{display:false}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxRotation:45}}}}}}}}}});");
+    }
+    else
+    {
+        // Sustained benchmarks: show Heap Growth, CPU and Network charts
+        var heapData = new StringBuilder();
+        var heapColors = new StringBuilder();
+        var cpuData = new StringBuilder();
+        var cpuColors = new StringBuilder();
+        var netSentData = new StringBuilder();
+        var netRecvData = new StringBuilder();
+        first = true;
+        foreach (var r in results)
+        {
+            if (!first) { heapData.Append(','); heapColors.Append(','); cpuData.Append(','); cpuColors.Append(','); netSentData.Append(','); netRecvData.Append(','); }
+            first = false;
+            var heapGrowthMb = r.FinalHeapMb - r.InitialHeapMb;
+            heapData.Append(CultureInfo.InvariantCulture, $"{heapGrowthMb:F2}");
+            heapColors.Append(heapGrowthMb > 5 ? "'#f59e0b'" : heapGrowthMb < 0 ? "'#06b6d4'" : "'#10b981'");
+            cpuData.Append(CultureInfo.InvariantCulture, $"{r.AvgCpuPercent:F1}");
+            cpuColors.Append(r.AvgCpuPercent > 50 ? "'#f59e0b'" : "'#8b5cf6'");
+            var sentMb = r.NetworkBytesSent / (1024.0 * 1024.0);
+            var recvMb = r.NetworkBytesReceived / (1024.0 * 1024.0);
+            netSentData.Append(CultureInfo.InvariantCulture, $"{sentMb:F2}");
+            netRecvData.Append(CultureInfo.InvariantCulture, $"{recvMb:F2}");
+        }
+
+        sb.Append(CultureInfo.InvariantCulture, $@"
+        var heapChart=new Chart(document.getElementById('heapChart'),{{type:'bar',data:{{labels:[{chartLabels}],datasets:[{{label:'Crescimento Heap (MB)',data:[{heapData}],backgroundColor:[{heapColors}],borderWidth:0,borderRadius:4}}]}},options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}},title:{{display:true,text:'Heap Growth por Benchmark (MB)',color:getComputedStyle(document.body).getPropertyValue('--text').trim()}}}},scales:{{y:{{grid:{{color:'rgba(148,163,184,0.1)'}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}},x:{{grid:{{display:false}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxRotation:45}}}}}}}}}});
+        var cpuChart=new Chart(document.getElementById('cpuChart'),{{type:'bar',data:{{labels:[{chartLabels}],datasets:[{{label:'CPU Medio (%)',data:[{cpuData}],backgroundColor:[{cpuColors}],borderWidth:0,borderRadius:4}}]}},options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}},title:{{display:true,text:'CPU Medio por Benchmark (%)',color:getComputedStyle(document.body).getPropertyValue('--text').trim()}}}},scales:{{y:{{beginAtZero:true,grid:{{color:'rgba(148,163,184,0.1)'}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}},x:{{grid:{{display:false}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxRotation:45}}}}}}}}}});
+        var networkChart=new Chart(document.getElementById('networkChart'),{{type:'bar',data:{{labels:[{chartLabels}],datasets:[{{label:'Enviado (MB)',data:[{netSentData}],backgroundColor:'#10b981',borderWidth:0,borderRadius:4}},{{label:'Recebido (MB)',data:[{netRecvData}],backgroundColor:'#3b82f6',borderWidth:0,borderRadius:4}}]}},options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:true,labels:{{color:getComputedStyle(document.body).getPropertyValue('--text').trim(),usePointStyle:true,boxWidth:8}}}},title:{{display:true,text:'Network I/O por Benchmark (MB)',color:getComputedStyle(document.body).getPropertyValue('--text').trim()}}}},scales:{{y:{{beginAtZero:true,grid:{{color:'rgba(148,163,184,0.1)'}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}},x:{{grid:{{display:false}},ticks:{{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxRotation:45}}}}}}}}}});");
+    }
 
     sb.Append("""
 
         document.querySelectorAll('.detail-header').forEach(h=>h.addEventListener('click',()=>h.closest('.detail').classList.toggle('collapsed')));
+        var overviewCharts=[]; if(typeof meanChart!=='undefined')overviewCharts.push(meanChart); if(typeof heapChart!=='undefined')overviewCharts.push(heapChart); if(typeof cpuChart!=='undefined')overviewCharts.push(cpuChart); if(typeof networkChart!=='undefined')overviewCharts.push(networkChart);
         function toggleTheme(){document.body.classList.toggle('light-theme');localStorage.setItem('bench-theme',document.body.classList.contains('light-theme')?'light':'dark');updateChart();timelineCharts.forEach(c=>c.update());}
-        function updateChart(){var c=getComputedStyle(document.body);meanChart.options.plugins.title.color=c.getPropertyValue('--text').trim();meanChart.options.scales.y.ticks.color=c.getPropertyValue('--muted').trim();meanChart.options.scales.x.ticks.color=c.getPropertyValue('--muted').trim();meanChart.update();}
+        function updateChart(){var c=getComputedStyle(document.body);var txt=c.getPropertyValue('--text').trim();var mt=c.getPropertyValue('--muted').trim();overviewCharts.forEach(function(ch){ch.options.plugins.title.color=txt;if(ch.options.plugins.legend&&ch.options.plugins.legend.display){ch.options.plugins.legend.labels.color=txt;}ch.options.scales.y.ticks.color=mt;ch.options.scales.x.ticks.color=mt;ch.update();});}
 
         // Timeline charts for each benchmark with samples
         var timelineCharts=[];
@@ -517,15 +624,18 @@ static string GenerateHtml(List<BenchmarkResult> results, string gitBranch, stri
             if(!samples.length)return;
             var t0=samples[0].t;
             var labels=samples.map(function(s){var d=s.t-t0;var m=Math.floor(d/60);var sec=d%60;return m+':'+(sec<10?'0':'')+sec;});
+            function delta(arr,key){return arr.map(function(s,i){return i===0?0:s[key]-arr[i-1][key];});}
             var chart=new Chart(canvas,{type:'line',data:{labels:labels,datasets:[
-                {label:'GC Heap (MB)',data:samples.map(function(s){return s.heap;}),borderColor:'#8b5cf6',backgroundColor:'rgba(139,92,246,0.1)',fill:true,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y'},
-                {label:'Working Set (MB)',data:samples.map(function(s){return s.ws;}),borderColor:'#06b6d4',backgroundColor:'rgba(6,182,212,0.1)',fill:true,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y'},
+                {label:'Heap GC (MB)',data:samples.map(function(s){return s.heap;}),borderColor:'#8b5cf6',backgroundColor:'rgba(139,92,246,0.1)',fill:true,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y'},
+                {label:'Conjunto de Trabalho (MB)',data:samples.map(function(s){return s.ws;}),borderColor:'#06b6d4',backgroundColor:'rgba(6,182,212,0.1)',fill:true,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y'},
                 {label:'CPU (%)',data:samples.map(function(s){return s.cpu;}),borderColor:'#f59e0b',backgroundColor:'rgba(245,158,11,0.1)',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y1'},
-                {label:'Net Sent (KB)',data:samples.map(function(s){return s.netS/1024;}),borderColor:'#10b981',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
-                {label:'Net Recv (KB)',data:samples.map(function(s){return s.netR/1024;}),borderColor:'#3b82f6',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
-                {label:'GC Gen0',data:samples.map(function(s){return s.g0;}),borderColor:'#ec4899',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
-                {label:'GC Gen1',data:samples.map(function(s){return s.g1;}),borderColor:'#f97316',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
-                {label:'GC Gen2',data:samples.map(function(s){return s.g2;}),borderColor:'#ef4444',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true}
+                {label:'Rede Enviado (KB)',data:samples.map(function(s){return s.netS/1024;}),borderColor:'#10b981',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'Rede Recebido (KB)',data:samples.map(function(s){return s.netR/1024;}),borderColor:'#3b82f6',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'\u0394 Rede Enviado (KB)',data:delta(samples,'netS').map(function(v){return v/1024;}),borderColor:'#34d399',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'\u0394 Rede Recebido (KB)',data:delta(samples,'netR').map(function(v){return v/1024;}),borderColor:'#60a5fa',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'GC Gen0',data:delta(samples,'g0'),borderColor:'#ec4899',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'GC Gen1',data:delta(samples,'g1'),borderColor:'#f97316',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true},
+                {label:'GC Gen2',data:delta(samples,'g2'),borderColor:'#ef4444',backgroundColor:'transparent',fill:false,tension:0.3,pointRadius:0,pointHitRadius:6,yAxisID:'y2',hidden:true}
             ]},options:{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},plugins:{legend:{position:'top',labels:{usePointStyle:true,boxWidth:8,color:getComputedStyle(document.body).getPropertyValue('--chart-legend').trim()}},tooltip:{mode:'index',intersect:false}},scales:{x:{display:true,title:{display:true,text:'Tempo (mm:ss)',color:getComputedStyle(document.body).getPropertyValue('--muted').trim()},ticks:{color:getComputedStyle(document.body).getPropertyValue('--muted').trim(),maxTicksLimit:20},grid:{color:'rgba(148,163,184,0.1)'}},y:{type:'linear',display:true,position:'left',title:{display:true,text:'Memoria (MB)',color:getComputedStyle(document.body).getPropertyValue('--muted').trim()},ticks:{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()},grid:{color:'rgba(148,163,184,0.1)'}},y1:{type:'linear',display:true,position:'right',title:{display:true,text:'CPU (%)',color:getComputedStyle(document.body).getPropertyValue('--muted').trim()},ticks:{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()},min:0,max:100,grid:{drawOnChartArea:false}},y2:{type:'linear',display:false,ticks:{color:getComputedStyle(document.body).getPropertyValue('--muted').trim()}}}}});
             timelineCharts.push(chart);
         });
@@ -554,6 +664,82 @@ static double ParseTimeToMs(string timeStr)
     if (s.EndsWith("s")) return double.TryParse(s[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out var sec) ? sec * 1_000 : 0;
     return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var raw) ? raw : 0;
 }
+
+static void AppendStatsRow(StringBuilder sb, string label, double[] sorted, int[] percentiles, string fmt)
+{
+    if (sorted.Length == 0)
+    {
+        sb.Append($"<tr><td>{label}</td>");
+        // 4 stats + percentiles columns
+        for (var i = 0; i < 4 + percentiles.Length; i++)
+            sb.Append("<td class=\"num\">-</td>");
+        sb.Append("</tr>");
+        return;
+    }
+
+    var min = sorted[0];
+    var max = sorted[^1];
+    var mean = sorted.Average();
+    var stddev = Math.Sqrt(sorted.Sum(v => (v - mean) * (v - mean)) / sorted.Length);
+    var p50 = Percentile(sorted, 50);
+
+    sb.Append(CultureInfo.InvariantCulture, $"<tr><td>{label}</td>");
+    sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{min.ToString(fmt, CultureInfo.InvariantCulture)}</td>");
+    sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{mean.ToString(fmt, CultureInfo.InvariantCulture)}</td>");
+    sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{max.ToString(fmt, CultureInfo.InvariantCulture)}</td>");
+    sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{stddev.ToString(fmt, CultureInfo.InvariantCulture)}</td>");
+
+    foreach (var p in percentiles)
+    {
+        var val = Percentile(sorted, p);
+        var valStr = val.ToString(fmt, CultureInfo.InvariantCulture);
+        if (p == 50 || p50 == 0)
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{valStr}</td>");
+        }
+        else
+        {
+            var pctDiff = ((val - p50) / Math.Abs(p50)) * 100.0;
+            var sign = pctDiff >= 0 ? "+" : "";
+            var cssClass = Math.Abs(pctDiff) < 5 ? "pct-neutral" : pctDiff > 0 ? "pct-up" : "pct-down";
+            sb.Append(CultureInfo.InvariantCulture, $"<td class=\"num\">{valStr} <span class=\"{cssClass}\">({sign}{pctDiff:F0}%)</span></td>");
+        }
+    }
+    sb.Append("</tr>");
+}
+
+static double Percentile(double[] sorted, int p)
+{
+    if (sorted.Length == 0) return 0;
+    var rank = (p / 100.0) * (sorted.Length - 1);
+    var lower = (int)Math.Floor(rank);
+    var upper = (int)Math.Ceiling(rank);
+    if (lower == upper) return sorted[lower];
+    var weight = rank - lower;
+    return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+static List<SampleData> ParseSamplesForPercentiles(string json)
+{
+    var results = new List<SampleData>();
+    try
+    {
+        var doc = JsonDocument.Parse(json);
+        foreach (var el in doc.RootElement.EnumerateArray())
+        {
+            results.Add(new SampleData(
+                Cpu: el.TryGetProperty("cpu", out var cpu) ? cpu.GetDouble() : 0,
+                Heap: el.TryGetProperty("heap", out var heap) ? heap.GetDouble() : 0,
+                Ws: el.TryGetProperty("ws", out var ws) ? ws.GetDouble() : 0,
+                NetS: el.TryGetProperty("netS", out var netS) ? netS.GetInt64() : 0,
+                NetR: el.TryGetProperty("netR", out var netR) ? netR.GetInt64() : 0));
+        }
+    }
+    catch { /* ignore parse errors */ }
+    return results;
+}
+
+internal sealed record SampleData(double Cpu, double Heap, double Ws, long NetS, long NetR);
 
 // --- Data classes ---
 


### PR DESCRIPTION
## Summary
- Corrigir gráfico zerado adaptando para benchmarks sustentados (Heap Growth MB, CPU Médio %, Network I/O MB)
- Adicionar `NetworkEventListener` para captura real de network I/O via `System.Net.Sockets` EventCounters
- Mover ambiente para card separado, adicionar tabela de estatísticas e percentis (P25-P99) no acordeão, corrigir GC delta no timeline, padronizar labels em pt-BR

Closes #117

## Test plan
- [x] Pipeline local passou (build, testes unitários, cobertura, mutação, integração)
- [ ] Verificar relatório HTML gerado com dados reais de benchmark
- [ ] Verificar gráficos de Heap Growth, CPU e Network no overview
- [ ] Verificar percentis e variação vs P50 nos acordeões
- [ ] Verificar timeline com GC delta e Δ Rede

🤖 Generated with [Claude Code](https://claude.com/claude-code)