### PR TITLE
chore: add playground console project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
             /o:"castelobrancolab" \
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" \
-            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
-            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
+            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
+            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
             /d:sonar.cpd.exclusions="**/Serialization.Avro/AvroSerializerBase.cs,**/Serialization.Protobuf/ProtobufSerializerBase.cs,**/Serialization.Parquet/ParquetSerializerBase.cs"
 
       - name: Build

--- a/Bedrock.sln
+++ b/Bedrock.sln
@@ -153,6 +153,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkReportGenerator", "tools\BenchmarkReportGenerator\BenchmarkReportGenerator.csproj", "{2FFA6103-F3C5-4DB6-A963-CEFDC735B113}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "playground", "playground", "{12E5C810-18C6-BE57-4EA6-3F3BE821652E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.ConsoleApp", "playground\Playground.ConsoleApp\Playground.ConsoleApp.csproj", "{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -547,6 +551,18 @@ Global
 		{2FFA6103-F3C5-4DB6-A963-CEFDC735B113}.Release|x64.Build.0 = Release|Any CPU
 		{2FFA6103-F3C5-4DB6-A963-CEFDC735B113}.Release|x86.ActiveCfg = Release|Any CPU
 		{2FFA6103-F3C5-4DB6-A963-CEFDC735B113}.Release|x86.Build.0 = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|x64.Build.0 = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -623,5 +639,6 @@ Global
 		{F6774A09-4328-9E81-2A8F-031260C197EC} = {05E827AB-7174-39B8-F658-50C00E1C9B26}
 		{B40E19A8-6DEB-428E-AAE0-262D16734E00} = {F6774A09-4328-9E81-2A8F-031260C197EC}
 		{2FFA6103-F3C5-4DB6-A963-CEFDC735B113} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{964BC52D-FB75-4194-B826-CAC6D3B2E1A1} = {12E5C810-18C6-BE57-4EA6-3F3BE821652E}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,25 +8,21 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.1" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-
     <!-- Serialization -->
     <PackageVersion Include="Apache.Arrow" Version="22.1.0" />
     <PackageVersion Include="Apache.Avro" Version="1.12.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.33.2" />
     <PackageVersion Include="protobuf-net" Version="3.2.56" />
-
     <!-- Database -->
     <PackageVersion Include="Npgsql" Version="10.0.1" />
-
     <!-- Integration Testing -->
     <PackageVersion Include="Testcontainers" Version="4.3.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.3.0" />
-
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/playground/Playground.ConsoleApp/GlobalUsings.cs
+++ b/playground/Playground.ConsoleApp/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Bedrock.BuildingBlocks.Core.ExecutionContexts;

--- a/playground/Playground.ConsoleApp/Playground.ConsoleApp.csproj
+++ b/playground/Playground.ConsoleApp/Playground.ConsoleApp.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BuildingBlocks\Core\Bedrock.BuildingBlocks.Core.csproj" />
+    <ProjectReference Include="..\..\src\BuildingBlocks\Observability\Bedrock.BuildingBlocks.Observability.csproj" />
+    <ProjectReference Include="..\..\tests\UnitTests\BuildingBlocks\Observability\Bedrock.UnitTests.BuildingBlocks.Observability.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+</Project>

--- a/playground/Playground.ConsoleApp/Program.cs
+++ b/playground/Playground.ConsoleApp/Program.cs
@@ -1,0 +1,50 @@
+﻿using System.Text.Json;
+using Bedrock.BuildingBlocks.Core.Ids;
+using Bedrock.BuildingBlocks.Core.TenantInfos;
+using Bedrock.BuildingBlocks.Observability.ExtensionMethods;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+var executionContext = Bedrock.BuildingBlocks.Core.ExecutionContexts.ExecutionContext.Create(
+    correlationId: Id.GenerateNewId(),
+    tenantInfo: TenantInfo.Create(code: Id.GenerateNewId(), name: "PlaygroundTenant"),
+    executionUser: "PlaygroundUser",
+    executionOrigin: "PlaygroundApp",
+    businessOperationCode: "PlaygroundRun",
+    minimumMessageType: Bedrock.BuildingBlocks.Core.ExecutionContexts.Models.Enums.MessageType.Information,
+    timeProvider: TimeProvider.System
+);
+
+var services = new ServiceCollection();
+services.AddLogging(builder => builder
+    .AddJsonConsole(options =>
+    {
+        options.IncludeScopes = true;
+        options.UseUtcTimestamp = true;
+        options.JsonWriterOptions = new JsonWriterOptions
+        {
+            Indented = true
+        };
+    })
+);
+
+var provider = services.BuildServiceProvider();
+var logger = provider.GetRequiredService<ILogger<Program>>();
+
+logger.LogInformationForDistributedTracing(
+    executionContext, 
+    "Playground iniciado 2. Nome: {Nome}",
+    args: [
+        "Marcelo"
+    ]
+);
+
+logger.LogInformation(
+    "Playground iniciado. Nome: {Nome}",
+    args: [
+        "Marcelo"
+    ]
+);
+
+logger.LogInformation("Press [Enter] to exit...");
+Console.ReadLine();


### PR DESCRIPTION
## Summary
- Adds `playground/Playground.ConsoleApp` console project for quick experimentation with BuildingBlocks
- Excludes `playground/` from SonarCloud analysis (issues and coverage)
- Adds `Microsoft.Extensions.Logging.Console` package reference

Closes #121

## Test plan
- [x] Local pipeline passes (build, unit tests, mutation tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)