### PR TITLE
fix: align CI coverage output with report generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,20 +157,22 @@ jobs:
 
       - name: Test with coverage
         run: |
-          mkdir -p coverage/raw
+          mkdir -p artifacts/coverage/raw
+          mkdir -p artifacts/test-results
 
           find tests/UnitTests -name "*.csproj" | while read project; do
             name=$(basename "$(dirname "$project")")
-            echo "Running tests for: $project (output: coverage/raw/$name.xml)"
+            echo "Running tests for: $name"
+
             dotnet-coverage collect "dotnet test --no-build $project" \
-              -f xml \
-              -o "coverage/raw/$name.xml"
+              -f cobertura \
+              -o "artifacts/coverage/raw/$name.cobertura.xml"
           done
 
-      - name: Merge coverage reports
+      - name: Merge coverage for SonarCloud
         run: |
           mkdir -p coverage
-          dotnet-coverage merge coverage/raw/*.xml \
+          dotnet-coverage merge artifacts/coverage/raw/*.cobertura.xml \
             -f xml \
             -o coverage/coverage.xml
 


### PR DESCRIPTION
## Summary
- Changed `dotnet-coverage collect` to output Cobertura XML format (`-f cobertura`) in `artifacts/coverage/raw/` so `generate-unittest-report.sh` can find the coverage files
- SonarCloud still receives VS Coverage XML via `dotnet-coverage merge` step (merged from Cobertura to XML)
- Root cause: CI was generating coverage in `coverage/raw/` in VS Coverage XML format, but report generator expects `*.cobertura.xml` in `artifacts/coverage/raw/`

## Test plan
- [ ] CI pipeline passes (build, architecture, test, mutation)
- [ ] Unit test HTML report artifact is generated and uploaded
- [ ] SonarCloud analysis still works with merged coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)