### PR TITLE
chore: incluir Testing.Architecture na cobertura e análise do SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
             /o:"castelobrancolab" \
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" \
-            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
-            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*" \
+            /d:sonar.exclusions="**/tests/**/*,**/scripts/**/*,**/obj/**/*,**/bin/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*,**/src/BuildingBlocks/Testing/Integration/**/*,**/src/BuildingBlocks/Testing/Attributes/**/*,**/src/BuildingBlocks/Testing/TestBase.cs,**/src/BuildingBlocks/Testing/ServiceCollectionFixture.cs" \
+            /d:sonar.coverage.exclusions="**/tests/**/*,**/samples/**/*,**/templates/**/*,**/tools/**/*,**/playground/**/*,**/src/BuildingBlocks/Testing/Benchmarks/**/*,**/src/BuildingBlocks/Testing/Integration/**/*,**/src/BuildingBlocks/Testing/Attributes/**/*,**/src/BuildingBlocks/Testing/TestBase.cs,**/src/BuildingBlocks/Testing/ServiceCollectionFixture.cs" \
             /d:sonar.cpd.exclusions="**/Serialization.Avro/AvroSerializerBase.cs,**/Serialization.Protobuf/ProtobufSerializerBase.cs,**/Serialization.Parquet/ParquetSerializerBase.cs"
 
       - name: Build (SonarCloud instrumented)

--- a/Bedrock.sln
+++ b/Bedrock.sln
@@ -175,6 +175,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.ArchitectureTests.Templates.Domain.Entities", "tests\ArchitectureTests\Templates\Domain.Entities\Bedrock.ArchitectureTests.Templates.Domain.Entities.csproj", "{AF54121A-334C-4A5D-ABFD-475666017F12}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing.Architecture", "Testing.Architecture", "{D81381B9-0497-DF61-824B-24962731D7FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bedrock.UnitTests.BuildingBlocks.Testing.Architecture", "tests\UnitTests\BuildingBlocks\Testing.Architecture\Bedrock.UnitTests.BuildingBlocks.Testing.Architecture.csproj", "{74355D89-EA27-4816-B19F-43FCD5E40062}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -629,6 +633,18 @@ Global
 		{AF54121A-334C-4A5D-ABFD-475666017F12}.Release|x64.Build.0 = Release|Any CPU
 		{AF54121A-334C-4A5D-ABFD-475666017F12}.Release|x86.ActiveCfg = Release|Any CPU
 		{AF54121A-334C-4A5D-ABFD-475666017F12}.Release|x86.Build.0 = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|x64.Build.0 = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Debug|x86.Build.0 = Debug|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|x64.ActiveCfg = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|x64.Build.0 = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|x86.ActiveCfg = Release|Any CPU
+		{74355D89-EA27-4816-B19F-43FCD5E40062}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -715,5 +731,7 @@ Global
 		{F2649C2A-3AFA-9322-C2B3-1581D61A275E} = {E5F6A7B8-C9D0-1234-EF01-345678901234}
 		{E5EEEE1B-F81D-0F80-6AD3-494B24999756} = {F2649C2A-3AFA-9322-C2B3-1581D61A275E}
 		{AF54121A-334C-4A5D-ABFD-475666017F12} = {E5EEEE1B-F81D-0F80-6AD3-494B24999756}
+		{D81381B9-0497-DF61-824B-24962731D7FB} = {A7B8C9D0-E1F2-3456-0123-567890123456}
+		{74355D89-EA27-4816-B19F-43FCD5E40062} = {D81381B9-0497-DF61-824B-24962731D7FB}
 	EndGlobalSection
 EndGlobal

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,7 +28,7 @@ for project in $(find tests/UnitTests -name "*.csproj"); do
         --results-directory "artifacts/coverage/raw/$name" \
         --logger "trx;LogFileName=results.trx" \
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
-           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[Bedrock.BuildingBlocks.Testing]*,[Bedrock.Templates.*]*,[Bedrock.Samples.*]*"
+           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[Bedrock.BuildingBlocks.Testing]Bedrock.BuildingBlocks.Testing.TestBase,[Bedrock.BuildingBlocks.Testing]Bedrock.BuildingBlocks.Testing.ServiceCollectionFixture,[Bedrock.BuildingBlocks.Testing]Bedrock.BuildingBlocks.Testing.Attributes.*,[Bedrock.BuildingBlocks.Testing]Bedrock.BuildingBlocks.Testing.Benchmarks.*,[Bedrock.BuildingBlocks.Testing]Bedrock.BuildingBlocks.Testing.Integration.*,[Bedrock.Templates.*]*,[Bedrock.Samples.*]*"
 
     # Copy coverage file to a known location
     coverage_file=$(find "artifacts/coverage/raw/$name" -name "coverage.cobertura.xml" 2>/dev/null | head -1)

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/Bedrock.UnitTests.BuildingBlocks.Testing.Architecture.csproj
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/Bedrock.UnitTests.BuildingBlocks.Testing.Architecture.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\BuildingBlocks\Testing\Bedrock.BuildingBlocks.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/SeverityTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/SeverityTests.cs
@@ -1,0 +1,105 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class SeverityTests : TestBase
+{
+    public SeverityTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void Severity_Error_ShouldHaveValue0()
+    {
+        // Arrange
+        LogArrange("Getting Error value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)Severity.Error;
+
+        // Assert
+        LogAssert("Verifying value is 0");
+        value.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Severity_Warning_ShouldHaveValue1()
+    {
+        // Arrange
+        LogArrange("Getting Warning value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)Severity.Warning;
+
+        // Assert
+        LogAssert("Verifying value is 1");
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Severity_Info_ShouldHaveValue2()
+    {
+        // Arrange
+        LogArrange("Getting Info value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)Severity.Info;
+
+        // Assert
+        LogAssert("Verifying value is 2");
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Severity_ToString_ShouldReturnName()
+    {
+        // Arrange
+        LogArrange("Getting enum names");
+
+        // Act & Assert
+        LogAct("Checking ToString values");
+        Severity.Error.ToString().ShouldBe("Error");
+        Severity.Warning.ToString().ShouldBe("Warning");
+        Severity.Info.ToString().ShouldBe("Info");
+
+        LogAssert("All ToString values correct");
+    }
+
+    [Fact]
+    public void Severity_AllValues_ShouldBeUnique()
+    {
+        // Arrange
+        LogArrange("Getting all Severity values");
+
+        // Act
+        LogAct("Checking uniqueness");
+        var values = Enum.GetValues<Severity>();
+        var uniqueValues = values.Select(v => (int)v).Distinct().Count();
+
+        // Assert
+        LogAssert("Verifying all values are unique");
+        uniqueValues.ShouldBe(values.Length);
+    }
+
+    [Fact]
+    public void Severity_ShouldHaveExactly3Values()
+    {
+        // Arrange
+        LogArrange("Getting all Severity values");
+
+        // Act
+        LogAct("Counting values");
+        var values = Enum.GetValues<Severity>();
+
+        // Assert
+        LogAssert("Verifying count is 3");
+        values.Length.ShouldBe(3);
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/ViolationTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/ViolationTests.cs
@@ -1,0 +1,46 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class ViolationTests : TestBase
+{
+    public ViolationTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void Violation_ShouldStoreAllRequiredProperties()
+    {
+        // Arrange
+        LogArrange("Creating a Violation with all required properties");
+
+        // Act
+        LogAct("Instantiating Violation");
+        var violation = new Violation
+        {
+            Rule = "SealedClass",
+            Severity = Severity.Error,
+            Adr = "docs/adr/001-sealed-entities.md",
+            Project = "Bedrock.BuildingBlocks.Domain",
+            File = "src/Entities/Customer.cs",
+            Line = 10,
+            Message = "Entity classes must be sealed",
+            LlmHint = "Add the sealed modifier to the class declaration"
+        };
+
+        // Assert
+        LogAssert("Verifying all properties are correctly stored");
+        violation.Rule.ShouldBe("SealedClass");
+        violation.Severity.ShouldBe(Severity.Error);
+        violation.Adr.ShouldBe("docs/adr/001-sealed-entities.md");
+        violation.Project.ShouldBe("Bedrock.BuildingBlocks.Domain");
+        violation.File.ShouldBe("src/Entities/Customer.cs");
+        violation.Line.ShouldBe(10);
+        violation.Message.ShouldBe("Entity classes must be sealed");
+        violation.LlmHint.ShouldBe("Add the sealed modifier to the class declaration");
+    }
+}


### PR DESCRIPTION
## Summary

- Ajustou exclusões de cobertura em `scripts/test.sh` para ser granular: exclui `TestBase`, `ServiceCollectionFixture`, `Attributes`, `Benchmarks` e `Integration`, mantendo `Architecture` incluído
- Ajustou exclusões do SonarCloud em `ci.yml` com a mesma granularidade
- Criou projeto de testes unitários `Bedrock.UnitTests.BuildingBlocks.Testing.Architecture` com testes para `Violation` e `Severity`

> **Nota**: O Stryker config para Testing.Architecture será criado em issue futura, quando houver testes unitários completos para as 70+ classes de Architecture.

Closes #160

## Test plan

- [x] Testes unitários passam localmente (7 testes, todos aprovados)
- [x] Mutation tests dos projetos existentes passam (sem regressão)
- [ ] Pipeline do GitHub Actions passa (build, architecture, unit tests, mutation)
- [ ] SonarCloud analisa corretamente os arquivos de `Testing/Architecture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)