### PR TITLE
test: add unit tests for Testing.Architecture base classes

### DIFF
--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/RuleAnalysisResultTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/RuleAnalysisResultTests.cs
@@ -1,0 +1,192 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class RuleAnalysisResultTests : TestBase
+{
+    public RuleAnalysisResultTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void RuleAnalysisResult_ShouldStoreAllRequiredProperties()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with all properties");
+        var typeResults = new List<TypeAnalysisResult>();
+
+        // Act
+        LogAct("Instantiating RuleAnalysisResult");
+        var result = new RuleAnalysisResult
+        {
+            RuleName = "DE001_SealedClass",
+            RuleDescription = "Classes must be sealed",
+            DefaultSeverity = Severity.Error,
+            AdrPath = "docs/adr/001.md",
+            ProjectName = "Domain",
+            TypeResults = typeResults
+        };
+
+        // Assert
+        LogAssert("Verifying all properties");
+        result.RuleName.ShouldBe("DE001_SealedClass");
+        result.RuleDescription.ShouldBe("Classes must be sealed");
+        result.DefaultSeverity.ShouldBe(Severity.Error);
+        result.AdrPath.ShouldBe("docs/adr/001.md");
+        result.ProjectName.ShouldBe("Domain");
+        result.TypeResults.ShouldBeSameAs(typeResults);
+    }
+
+    [Fact]
+    public void PassedCount_WithNoResults_ShouldReturn0()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with empty TypeResults");
+
+        // Act
+        LogAct("Getting PassedCount");
+        var result = CreateResult([]);
+
+        // Assert
+        LogAssert("Verifying PassedCount is 0");
+        result.PassedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FailedCount_WithNoResults_ShouldReturn0()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with empty TypeResults");
+
+        // Act
+        LogAct("Getting FailedCount");
+        var result = CreateResult([]);
+
+        // Assert
+        LogAssert("Verifying FailedCount is 0");
+        result.FailedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void PassedCount_WithMixedResults_ShouldCountOnlyPassed()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with mixed results");
+        var typeResults = new List<TypeAnalysisResult>
+        {
+            CreateTypeResult("Type1", TypeAnalysisStatus.Passed),
+            CreateTypeResult("Type2", TypeAnalysisStatus.Failed),
+            CreateTypeResult("Type3", TypeAnalysisStatus.Passed),
+            CreateTypeResult("Type4", TypeAnalysisStatus.Passed)
+        };
+
+        // Act
+        LogAct("Getting PassedCount");
+        var result = CreateResult(typeResults);
+
+        // Assert
+        LogAssert("Verifying PassedCount is 3");
+        result.PassedCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void FailedCount_WithMixedResults_ShouldCountOnlyFailed()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with mixed results");
+        var typeResults = new List<TypeAnalysisResult>
+        {
+            CreateTypeResult("Type1", TypeAnalysisStatus.Passed),
+            CreateTypeResult("Type2", TypeAnalysisStatus.Failed),
+            CreateTypeResult("Type3", TypeAnalysisStatus.Failed)
+        };
+
+        // Act
+        LogAct("Getting FailedCount");
+        var result = CreateResult(typeResults);
+
+        // Assert
+        LogAssert("Verifying FailedCount is 2");
+        result.FailedCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void PassedCount_WithAllPassed_ShouldEqualTotalCount()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with all passed");
+        var typeResults = new List<TypeAnalysisResult>
+        {
+            CreateTypeResult("Type1", TypeAnalysisStatus.Passed),
+            CreateTypeResult("Type2", TypeAnalysisStatus.Passed)
+        };
+
+        // Act
+        LogAct("Getting PassedCount");
+        var result = CreateResult(typeResults);
+
+        // Assert
+        LogAssert("Verifying PassedCount equals total");
+        result.PassedCount.ShouldBe(2);
+        result.FailedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FailedCount_WithAllFailed_ShouldEqualTotalCount()
+    {
+        // Arrange
+        LogArrange("Creating RuleAnalysisResult with all failed");
+        var typeResults = new List<TypeAnalysisResult>
+        {
+            CreateTypeResult("Type1", TypeAnalysisStatus.Failed),
+            CreateTypeResult("Type2", TypeAnalysisStatus.Failed)
+        };
+
+        // Act
+        LogAct("Getting FailedCount");
+        var result = CreateResult(typeResults);
+
+        // Assert
+        LogAssert("Verifying FailedCount equals total");
+        result.FailedCount.ShouldBe(2);
+        result.PassedCount.ShouldBe(0);
+    }
+
+    private static RuleAnalysisResult CreateResult(IReadOnlyList<TypeAnalysisResult> typeResults) =>
+        new()
+        {
+            RuleName = "TestRule",
+            RuleDescription = "Test description",
+            DefaultSeverity = Severity.Error,
+            AdrPath = "docs/adr/test.md",
+            ProjectName = "TestProject",
+            TypeResults = typeResults
+        };
+
+    private static TypeAnalysisResult CreateTypeResult(string typeName, TypeAnalysisStatus status) =>
+        new()
+        {
+            TypeName = typeName,
+            TypeFullName = $"global::{typeName}",
+            File = $"{typeName}.cs",
+            Line = 1,
+            Status = status,
+            Violation = status == TypeAnalysisStatus.Failed
+                ? new Violation
+                {
+                    Rule = "TestRule",
+                    Severity = Severity.Error,
+                    Adr = "docs/adr/test.md",
+                    Project = "TestProject",
+                    File = $"{typeName}.cs",
+                    Line = 1,
+                    Message = "Test violation",
+                    LlmHint = "Fix it"
+                }
+                : null
+        };
+}

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/RuleTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/RuleTests.cs
@@ -1,0 +1,356 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class RuleTests : TestBase
+{
+    public RuleTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void Analyze_WithEmptyCompilations_ShouldReturnEmptyResults()
+    {
+        // Arrange
+        LogArrange("Creating rule with empty compilations");
+        var rule = new AlwaysPassRule();
+        var compilations = new Dictionary<string, Compilation>();
+
+        // Act
+        LogAct("Analyzing empty compilations");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying empty results");
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_WithPassingRule_ShouldReturnPassedResults()
+    {
+        // Arrange
+        LogArrange("Creating compilation with a simple class");
+        var rule = new AlwaysPassRule();
+        var compilations = CreateCompilations("public class TestClass { }");
+
+        // Act
+        LogAct("Analyzing with always-pass rule");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying passed results");
+        results.Count.ShouldBe(1);
+        results[0].RuleName.ShouldBe("AlwaysPass");
+        results[0].ProjectName.ShouldBe("TestProject");
+
+        var passedTypes = results[0].TypeResults.Where(t => t.Status == TypeAnalysisStatus.Passed).ToList();
+        passedTypes.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_WithFailingRule_ShouldReturnFailedResults()
+    {
+        // Arrange
+        LogArrange("Creating compilation with a simple class");
+        var rule = new AlwaysFailRule();
+        var compilations = CreateCompilations("public class TestClass { }");
+
+        // Act
+        LogAct("Analyzing with always-fail rule");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying failed results");
+        results.Count.ShouldBe(1);
+
+        var failedTypes = results[0].TypeResults.Where(t => t.Status == TypeAnalysisStatus.Failed).ToList();
+        failedTypes.ShouldNotBeEmpty();
+        failedTypes[0].Violation.ShouldNotBeNull();
+        failedTypes[0].Violation!.Rule.ShouldBe("AlwaysFail");
+    }
+
+    [Fact]
+    public void Analyze_ShouldPopulateRuleMetadataInResults()
+    {
+        // Arrange
+        LogArrange("Creating rule to verify metadata population");
+        var rule = new AlwaysPassRule();
+        var compilations = CreateCompilations("public class TestClass { }");
+
+        // Act
+        LogAct("Analyzing");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying rule metadata in results");
+        results[0].RuleName.ShouldBe("AlwaysPass");
+        results[0].RuleDescription.ShouldBe("Always passes");
+        results[0].DefaultSeverity.ShouldBe(Severity.Error);
+        results[0].AdrPath.ShouldBe("docs/adr/test.md");
+    }
+
+    [Fact]
+    public void Analyze_ShouldPopulateTypeAnalysisResultFields()
+    {
+        // Arrange
+        LogArrange("Creating compilation to check type result fields");
+        var rule = new AlwaysPassRule();
+        var compilations = CreateCompilations("public class MyEntity { }");
+
+        // Act
+        LogAct("Analyzing");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying type analysis result fields");
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "MyEntity");
+        typeResult.ShouldNotBeNull();
+        typeResult.TypeFullName.ShouldContain("MyEntity");
+        typeResult.Line.ShouldBeGreaterThan(0);
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+        typeResult.Violation.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleTypes_ShouldAnalyzeEach()
+    {
+        // Arrange
+        LogArrange("Creating compilation with multiple classes");
+        var rule = new AlwaysPassRule();
+        var source = """
+            public class ClassA { }
+            public class ClassB { }
+            public class ClassC { }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing multiple types");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying all types analyzed");
+        var typeNames = results[0].TypeResults.Select(t => t.TypeName).ToList();
+        typeNames.ShouldContain("ClassA");
+        typeNames.ShouldContain("ClassB");
+        typeNames.ShouldContain("ClassC");
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleProjects_ShouldReturnResultPerProject()
+    {
+        // Arrange
+        LogArrange("Creating multiple compilations");
+        var rule = new AlwaysPassRule();
+        var compilations = new Dictionary<string, Compilation>
+        {
+            ["ProjectA"] = CreateSingleCompilation("public class TypeA { }", "ProjectA"),
+            ["ProjectB"] = CreateSingleCompilation("public class TypeB { }", "ProjectB")
+        };
+
+        // Act
+        LogAct("Analyzing multiple projects");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying result per project");
+        results.Count.ShouldBe(2);
+        results.Select(r => r.ProjectName).ShouldContain("ProjectA");
+        results.Select(r => r.ProjectName).ShouldContain("ProjectB");
+    }
+
+    [Fact]
+    public void Analyze_ShouldIgnoreAutoGeneratedProgramClass()
+    {
+        // Arrange
+        LogArrange("Creating compilation with Program class");
+        var rule = new AlwaysPassRule();
+        var source = """
+            public class Program { static void Main() { } }
+            public class RealClass { }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying Program class is filtered out");
+        var typeNames = results[0].TypeResults.Select(t => t.TypeName).ToList();
+        typeNames.ShouldNotContain("Program");
+        typeNames.ShouldContain("RealClass");
+    }
+
+    [Fact]
+    public void Analyze_WithNestedTypes_ShouldIncludeNested()
+    {
+        // Arrange
+        LogArrange("Creating compilation with nested types");
+        var rule = new AlwaysPassRule();
+        var source = """
+            public class Outer
+            {
+                public class Inner { }
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying nested type included");
+        var typeNames = results[0].TypeResults.Select(t => t.TypeName).ToList();
+        typeNames.ShouldContain("Outer");
+        typeNames.ShouldContain("Inner");
+    }
+
+    [Fact]
+    public void Analyze_WithConditionalRule_ShouldMixPassAndFail()
+    {
+        // Arrange
+        LogArrange("Creating compilation with sealed and non-sealed classes");
+        var rule = new SealedOnlyRule();
+        var source = """
+            public sealed class SealedClass { }
+            public class NonSealedClass { }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing with sealed-only rule");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying mixed results");
+        var sealedResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "SealedClass");
+        var nonSealedResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "NonSealedClass");
+
+        sealedResult.ShouldNotBeNull();
+        sealedResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+
+        nonSealedResult.ShouldNotBeNull();
+        nonSealedResult.Status.ShouldBe(TypeAnalysisStatus.Failed);
+        nonSealedResult.Violation.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Analyze_FailedViolation_ShouldContainCorrectMetadata()
+    {
+        // Arrange
+        LogArrange("Creating compilation to check violation metadata");
+        var rule = new AlwaysFailRule();
+        var compilations = CreateCompilations("public class TestClass { }");
+
+        // Act
+        LogAct("Analyzing with always-fail rule");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying violation metadata");
+        var typeResult = results[0].TypeResults.First(t => t.TypeName == "TestClass");
+        var violation = typeResult.Violation!;
+
+        violation.Rule.ShouldBe("AlwaysFail");
+        violation.Severity.ShouldBe(Severity.Error);
+        violation.Adr.ShouldBe("docs/adr/test.md");
+        violation.Project.ShouldBe("TestProject");
+        violation.Message.ShouldNotBeNullOrEmpty();
+        violation.LlmHint.ShouldNotBeNullOrEmpty();
+    }
+
+    #region Test Rule Implementations
+
+    private sealed class AlwaysPassRule : Rule
+    {
+        public override string Name => "AlwaysPass";
+        public override string Description => "Always passes";
+        public override Severity DefaultSeverity => Severity.Error;
+        public override string AdrPath => "docs/adr/test.md";
+
+        protected override Violation? AnalyzeType(TypeContext context) => null;
+    }
+
+    private sealed class AlwaysFailRule : Rule
+    {
+        public override string Name => "AlwaysFail";
+        public override string Description => "Always fails";
+        public override Severity DefaultSeverity => Severity.Error;
+        public override string AdrPath => "docs/adr/test.md";
+
+        protected override Violation? AnalyzeType(TypeContext context) => new()
+        {
+            Rule = Name,
+            Severity = DefaultSeverity,
+            Adr = AdrPath,
+            Project = context.ProjectName,
+            File = context.RelativeFilePath,
+            Line = context.LineNumber,
+            Message = "Always fails",
+            LlmHint = "This rule always fails"
+        };
+    }
+
+    private sealed class SealedOnlyRule : Rule
+    {
+        public override string Name => "SealedOnly";
+        public override string Description => "Classes must be sealed";
+        public override Severity DefaultSeverity => Severity.Error;
+        public override string AdrPath => "docs/adr/test.md";
+
+        protected override Violation? AnalyzeType(TypeContext context)
+        {
+            if (context.Type.IsSealed)
+                return null;
+
+            return new Violation
+            {
+                Rule = Name,
+                Severity = DefaultSeverity,
+                Adr = AdrPath,
+                Project = context.ProjectName,
+                File = context.RelativeFilePath,
+                Line = context.LineNumber,
+                Message = $"{context.Type.Name} must be sealed",
+                LlmHint = "Add the sealed modifier"
+            };
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Dictionary<string, Compilation> CreateCompilations(string source)
+    {
+        return new Dictionary<string, Compilation>
+        {
+            ["TestProject"] = CreateSingleCompilation(source, "TestProject")
+        };
+    }
+
+    private static Compilation CreateSingleCompilation(string source, string assemblyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "TestFile.cs");
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+        };
+
+        return CSharpCompilation.Create(
+            assemblyName,
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    #endregion
+}

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/TypeAnalysisResultTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/TypeAnalysisResultTests.cs
@@ -1,0 +1,101 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class TypeAnalysisResultTests : TestBase
+{
+    public TypeAnalysisResultTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void TypeAnalysisResult_Passed_ShouldStoreAllProperties()
+    {
+        // Arrange
+        LogArrange("Creating a passed TypeAnalysisResult");
+
+        // Act
+        LogAct("Instantiating TypeAnalysisResult with Passed status");
+        var result = new TypeAnalysisResult
+        {
+            TypeName = "OrderEntity",
+            TypeFullName = "global::Bedrock.Domain.OrderEntity",
+            File = "src/Domain/OrderEntity.cs",
+            Line = 10,
+            Status = TypeAnalysisStatus.Passed,
+            Violation = null
+        };
+
+        // Assert
+        LogAssert("Verifying all properties are correctly stored");
+        result.TypeName.ShouldBe("OrderEntity");
+        result.TypeFullName.ShouldBe("global::Bedrock.Domain.OrderEntity");
+        result.File.ShouldBe("src/Domain/OrderEntity.cs");
+        result.Line.ShouldBe(10);
+        result.Status.ShouldBe(TypeAnalysisStatus.Passed);
+        result.Violation.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TypeAnalysisResult_Failed_ShouldStoreViolation()
+    {
+        // Arrange
+        LogArrange("Creating a failed TypeAnalysisResult with violation");
+        var violation = new Violation
+        {
+            Rule = "SealedClass",
+            Severity = Severity.Error,
+            Adr = "docs/adr/001.md",
+            Project = "Domain",
+            File = "src/Domain/OrderEntity.cs",
+            Line = 10,
+            Message = "Must be sealed",
+            LlmHint = "Add sealed modifier"
+        };
+
+        // Act
+        LogAct("Instantiating TypeAnalysisResult with Failed status");
+        var result = new TypeAnalysisResult
+        {
+            TypeName = "OrderEntity",
+            TypeFullName = "global::Bedrock.Domain.OrderEntity",
+            File = "src/Domain/OrderEntity.cs",
+            Line = 10,
+            Status = TypeAnalysisStatus.Failed,
+            Violation = violation
+        };
+
+        // Assert
+        LogAssert("Verifying violation is stored");
+        result.Status.ShouldBe(TypeAnalysisStatus.Failed);
+        result.Violation.ShouldNotBeNull();
+        result.Violation.Rule.ShouldBe("SealedClass");
+        result.Violation.Severity.ShouldBe(Severity.Error);
+    }
+
+    [Fact]
+    public void TypeAnalysisResult_ViolationIsOptional_DefaultIsNull()
+    {
+        // Arrange
+        LogArrange("Creating TypeAnalysisResult without explicit Violation");
+
+        // Act
+        LogAct("Instantiating with Passed status and no Violation");
+        var result = new TypeAnalysisResult
+        {
+            TypeName = "Test",
+            TypeFullName = "global::Test",
+            File = "Test.cs",
+            Line = 1,
+            Status = TypeAnalysisStatus.Passed
+        };
+
+        // Assert
+        LogAssert("Verifying Violation defaults to null");
+        result.Violation.ShouldBeNull();
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/TypeAnalysisStatusTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/TypeAnalysisStatusTests.cs
@@ -1,0 +1,89 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class TypeAnalysisStatusTests : TestBase
+{
+    public TypeAnalysisStatusTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void TypeAnalysisStatus_Passed_ShouldHaveValue0()
+    {
+        // Arrange
+        LogArrange("Getting Passed value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)TypeAnalysisStatus.Passed;
+
+        // Assert
+        LogAssert("Verifying value is 0");
+        value.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TypeAnalysisStatus_Failed_ShouldHaveValue1()
+    {
+        // Arrange
+        LogArrange("Getting Failed value");
+
+        // Act
+        LogAct("Checking enum value");
+        var value = (int)TypeAnalysisStatus.Failed;
+
+        // Assert
+        LogAssert("Verifying value is 1");
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TypeAnalysisStatus_ShouldHaveExactly2Values()
+    {
+        // Arrange
+        LogArrange("Getting all TypeAnalysisStatus values");
+
+        // Act
+        LogAct("Counting values");
+        var values = Enum.GetValues<TypeAnalysisStatus>();
+
+        // Assert
+        LogAssert("Verifying count is 2");
+        values.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void TypeAnalysisStatus_AllValues_ShouldBeUnique()
+    {
+        // Arrange
+        LogArrange("Getting all TypeAnalysisStatus values");
+
+        // Act
+        LogAct("Checking uniqueness");
+        var values = Enum.GetValues<TypeAnalysisStatus>();
+        var uniqueValues = values.Select(v => (int)v).Distinct().Count();
+
+        // Assert
+        LogAssert("Verifying all values are unique");
+        uniqueValues.ShouldBe(values.Length);
+    }
+
+    [Fact]
+    public void TypeAnalysisStatus_ToString_ShouldReturnName()
+    {
+        // Arrange
+        LogArrange("Getting enum names");
+
+        // Act & Assert
+        LogAct("Checking ToString values");
+        TypeAnalysisStatus.Passed.ToString().ShouldBe("Passed");
+        TypeAnalysisStatus.Failed.ToString().ShouldBe("Failed");
+
+        LogAssert("All ToString values correct");
+    }
+}

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/ViolationManagerTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/ViolationManagerTests.cs
@@ -1,0 +1,550 @@
+using System.Text.Json;
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture;
+
+public class ViolationManagerTests : TestBase
+{
+    public ViolationManagerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void NewManager_ShouldHaveEmptyCollections()
+    {
+        // Arrange
+        LogArrange("Creating new ViolationManager");
+
+        // Act
+        LogAct("Instantiating ViolationManager");
+        var manager = new ViolationManager();
+
+        // Assert
+        LogAssert("Verifying empty state");
+        manager.Violations.ShouldBeEmpty();
+        manager.RuleResults.ShouldBeEmpty();
+        manager.HasErrors.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddRuleResults_WithPassedResults_ShouldNotAddViolations()
+    {
+        // Arrange
+        LogArrange("Creating manager with passed results");
+        var manager = new ViolationManager();
+        var results = new[]
+        {
+            CreateRuleResult("Rule1", [
+                CreateTypeResult("Type1", TypeAnalysisStatus.Passed),
+                CreateTypeResult("Type2", TypeAnalysisStatus.Passed)
+            ])
+        };
+
+        // Act
+        LogAct("Adding passed rule results");
+        manager.AddRuleResults(results);
+
+        // Assert
+        LogAssert("Verifying no violations added");
+        manager.Violations.ShouldBeEmpty();
+        manager.RuleResults.Count.ShouldBe(1);
+        manager.HasErrors.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddRuleResults_WithFailedResults_ShouldExtractViolations()
+    {
+        // Arrange
+        LogArrange("Creating manager with failed results");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("Rule1", Severity.Error);
+        var results = new[]
+        {
+            CreateRuleResult("Rule1", [
+                CreateTypeResult("Type1", TypeAnalysisStatus.Passed),
+                CreateTypeResultWithViolation("Type2", violation)
+            ])
+        };
+
+        // Act
+        LogAct("Adding results with violations");
+        manager.AddRuleResults(results);
+
+        // Assert
+        LogAssert("Verifying violations extracted");
+        manager.Violations.Count.ShouldBe(1);
+        manager.Violations[0].ShouldBeSameAs(violation);
+        manager.RuleResults.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HasErrors_WithErrorViolations_ShouldReturnTrue()
+    {
+        // Arrange
+        LogArrange("Creating manager with error violations");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("Rule1", Severity.Error);
+        var results = new[]
+        {
+            CreateRuleResult("Rule1", [
+                CreateTypeResultWithViolation("Type1", violation)
+            ])
+        };
+
+        // Act
+        LogAct("Adding error violations");
+        manager.AddRuleResults(results);
+
+        // Assert
+        LogAssert("Verifying HasErrors is true");
+        manager.HasErrors.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasErrors_WithOnlyWarnings_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating manager with warning-only violations");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("Rule1", Severity.Warning);
+        var results = new[]
+        {
+            CreateRuleResult("Rule1", [
+                CreateTypeResultWithViolation("Type1", violation)
+            ])
+        };
+
+        // Act
+        LogAct("Adding warning violations");
+        manager.AddRuleResults(results);
+
+        // Assert
+        LogAssert("Verifying HasErrors is false");
+        manager.HasErrors.ShouldBeFalse();
+        manager.Violations.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HasErrors_WithOnlyInfos_ShouldReturnFalse()
+    {
+        // Arrange
+        LogArrange("Creating manager with info-only violations");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("Rule1", Severity.Info);
+        var results = new[]
+        {
+            CreateRuleResult("Rule1", [
+                CreateTypeResultWithViolation("Type1", violation)
+            ])
+        };
+
+        // Act
+        LogAct("Adding info violations");
+        manager.AddRuleResults(results);
+
+        // Assert
+        LogAssert("Verifying HasErrors is false");
+        manager.HasErrors.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddRuleResults_MultipleCalls_ShouldAccumulate()
+    {
+        // Arrange
+        LogArrange("Creating manager for multiple AddRuleResults calls");
+        var manager = new ViolationManager();
+        var violation1 = CreateViolation("Rule1", Severity.Error);
+        var violation2 = CreateViolation("Rule2", Severity.Warning);
+
+        // Act
+        LogAct("Adding results in multiple calls");
+        manager.AddRuleResults([CreateRuleResult("Rule1", [CreateTypeResultWithViolation("Type1", violation1)])]);
+        manager.AddRuleResults([CreateRuleResult("Rule2", [CreateTypeResultWithViolation("Type2", violation2)])]);
+
+        // Assert
+        LogAssert("Verifying accumulation");
+        manager.Violations.Count.ShouldBe(2);
+        manager.RuleResults.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void WritePendingFiles_ShouldCreateDirectoryAndFiles()
+    {
+        // Arrange
+        LogArrange("Creating manager with violations for pending files");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("TestRule", Severity.Error);
+        manager.AddRuleResults([CreateRuleResult("TestRule", [CreateTypeResultWithViolation("Type1", violation)])]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+
+        try
+        {
+            // Act
+            LogAct("Writing pending files");
+            manager.WritePendingFiles(tempDir);
+
+            // Assert
+            LogAssert("Verifying pending files created");
+            Directory.Exists(tempDir).ShouldBeTrue();
+            var files = Directory.GetFiles(tempDir, "architecture_*.txt");
+            files.Length.ShouldBe(1);
+
+            var content = File.ReadAllText(files[0]);
+            content.ShouldContain("RULE: TestRule");
+            content.ShouldContain("SEVERITY: Error");
+            content.ShouldContain("ADR: docs/adr/test.md");
+            content.ShouldContain("PROJECT: TestProject");
+            content.ShouldContain("FILE: Type1.cs");
+            content.ShouldContain("LINE: 1");
+            content.ShouldContain("MESSAGE: Test violation");
+            content.ShouldContain("LLM_HINT: Fix it");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WritePendingFiles_WithMultipleViolations_ShouldCreateMultipleFiles()
+    {
+        // Arrange
+        LogArrange("Creating manager with multiple violations");
+        var manager = new ViolationManager();
+        var violation1 = CreateViolation("RuleA", Severity.Error);
+        var violation2 = CreateViolation("RuleB", Severity.Warning);
+        manager.AddRuleResults([
+            CreateRuleResult("RuleA", [CreateTypeResultWithViolation("Type1", violation1)]),
+            CreateRuleResult("RuleB", [CreateTypeResultWithViolation("Type2", violation2)])
+        ]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+
+        try
+        {
+            // Act
+            LogAct("Writing pending files");
+            manager.WritePendingFiles(tempDir);
+
+            // Assert
+            LogAssert("Verifying multiple files created");
+            var files = Directory.GetFiles(tempDir, "architecture_*.txt");
+            files.Length.ShouldBe(2);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WritePendingFiles_FileNaming_ShouldUseLowercaseRuleAndSequentialNumber()
+    {
+        // Arrange
+        LogArrange("Creating manager to verify file naming convention");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("DE001_SealedClass", Severity.Error);
+        manager.AddRuleResults([CreateRuleResult("DE001_SealedClass", [CreateTypeResultWithViolation("Type1", violation)])]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+
+        try
+        {
+            // Act
+            LogAct("Writing pending files");
+            manager.WritePendingFiles(tempDir);
+
+            // Assert
+            LogAssert("Verifying file naming convention");
+            var files = Directory.GetFiles(tempDir, "*.txt");
+            var fileName = Path.GetFileName(files[0]);
+            fileName.ShouldBe("architecture_de001_sealedclass_001.txt");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WritePendingFiles_WithNoViolations_ShouldCreateEmptyDirectory()
+    {
+        // Arrange
+        LogArrange("Creating manager without violations");
+        var manager = new ViolationManager();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+
+        try
+        {
+            // Act
+            LogAct("Writing pending files with no violations");
+            manager.WritePendingFiles(tempDir);
+
+            // Assert
+            LogAssert("Verifying directory created with no files");
+            Directory.Exists(tempDir).ShouldBeTrue();
+            Directory.GetFiles(tempDir).Length.ShouldBe(0);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJsonReport_ShouldCreateValidJsonFile()
+    {
+        // Arrange
+        LogArrange("Creating manager for JSON report");
+        var manager = new ViolationManager();
+        var violation = CreateViolation("TestRule", Severity.Error);
+        manager.AddRuleResults([
+            CreateRuleResult("TestRule", [
+                CreateTypeResult("PassedType", TypeAnalysisStatus.Passed),
+                CreateTypeResultWithViolation("FailedType", violation)
+            ])
+        ]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+        var outputPath = Path.Combine(tempDir, "report.json");
+
+        try
+        {
+            // Act
+            LogAct("Writing JSON report");
+            manager.WriteJsonReport(outputPath);
+
+            // Assert
+            LogAssert("Verifying JSON report");
+            File.Exists(outputPath).ShouldBeTrue();
+
+            var json = File.ReadAllText(outputPath);
+            var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            root.GetProperty("totalTypesAnalyzed").GetInt32().ShouldBe(2);
+            root.GetProperty("totalPassed").GetInt32().ShouldBe(1);
+            root.GetProperty("totalViolations").GetInt32().ShouldBe(1);
+            root.GetProperty("errors").GetInt32().ShouldBe(1);
+            root.GetProperty("warnings").GetInt32().ShouldBe(0);
+            root.GetProperty("infos").GetInt32().ShouldBe(0);
+            root.GetProperty("ruleResults").GetArrayLength().ShouldBe(1);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJsonReport_ShouldIncludeTimestamp()
+    {
+        // Arrange
+        LogArrange("Creating manager for timestamp check");
+        var manager = new ViolationManager();
+        manager.AddRuleResults([CreateRuleResult("TestRule", [CreateTypeResult("Type1", TypeAnalysisStatus.Passed)])]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+        var outputPath = Path.Combine(tempDir, "report.json");
+
+        try
+        {
+            // Act
+            LogAct("Writing JSON report");
+            manager.WriteJsonReport(outputPath);
+
+            // Assert
+            LogAssert("Verifying timestamp exists");
+            var json = File.ReadAllText(outputPath);
+            var doc = JsonDocument.Parse(json);
+            var timestamp = doc.RootElement.GetProperty("timestamp").GetString();
+            timestamp.ShouldNotBeNullOrEmpty();
+            timestamp.ShouldEndWith("Z");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJsonReport_WithMixedSeverities_ShouldCountCorrectly()
+    {
+        // Arrange
+        LogArrange("Creating manager with mixed severity violations");
+        var manager = new ViolationManager();
+        manager.AddRuleResults([
+            CreateRuleResult("Rule1", [
+                CreateTypeResultWithViolation("Type1", CreateViolation("Rule1", Severity.Error)),
+                CreateTypeResultWithViolation("Type2", CreateViolation("Rule1", Severity.Warning)),
+                CreateTypeResultWithViolation("Type3", CreateViolation("Rule1", Severity.Info)),
+                CreateTypeResultWithViolation("Type4", CreateViolation("Rule1", Severity.Error))
+            ])
+        ]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+        var outputPath = Path.Combine(tempDir, "report.json");
+
+        try
+        {
+            // Act
+            LogAct("Writing JSON report");
+            manager.WriteJsonReport(outputPath);
+
+            // Assert
+            LogAssert("Verifying severity counts");
+            var json = File.ReadAllText(outputPath);
+            var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            root.GetProperty("errors").GetInt32().ShouldBe(2);
+            root.GetProperty("warnings").GetInt32().ShouldBe(1);
+            root.GetProperty("infos").GetInt32().ShouldBe(1);
+            root.GetProperty("totalViolations").GetInt32().ShouldBe(4);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJsonReport_WithNoResults_ShouldCreateEmptyReport()
+    {
+        // Arrange
+        LogArrange("Creating empty manager for JSON report");
+        var manager = new ViolationManager();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+        var outputPath = Path.Combine(tempDir, "report.json");
+
+        try
+        {
+            // Act
+            LogAct("Writing empty JSON report");
+            manager.WriteJsonReport(outputPath);
+
+            // Assert
+            LogAssert("Verifying empty report");
+            var json = File.ReadAllText(outputPath);
+            var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            root.GetProperty("totalTypesAnalyzed").GetInt32().ShouldBe(0);
+            root.GetProperty("totalPassed").GetInt32().ShouldBe(0);
+            root.GetProperty("totalViolations").GetInt32().ShouldBe(0);
+            root.GetProperty("ruleResults").GetArrayLength().ShouldBe(0);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJsonReport_RuleResults_ShouldBeOrderedByProjectThenRule()
+    {
+        // Arrange
+        LogArrange("Creating manager with multiple projects and rules");
+        var manager = new ViolationManager();
+        manager.AddRuleResults([
+            CreateRuleResultForProject("RuleB", "ProjectB", [CreateTypeResult("Type1", TypeAnalysisStatus.Passed)]),
+            CreateRuleResultForProject("RuleA", "ProjectA", [CreateTypeResult("Type2", TypeAnalysisStatus.Passed)]),
+            CreateRuleResultForProject("RuleA", "ProjectB", [CreateTypeResult("Type3", TypeAnalysisStatus.Passed)])
+        ]);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"bedrock_test_{Guid.NewGuid():N}");
+        var outputPath = Path.Combine(tempDir, "report.json");
+
+        try
+        {
+            // Act
+            LogAct("Writing JSON report");
+            manager.WriteJsonReport(outputPath);
+
+            // Assert
+            LogAssert("Verifying ordering by project then rule");
+            var json = File.ReadAllText(outputPath);
+            var doc = JsonDocument.Parse(json);
+            var ruleResults = doc.RootElement.GetProperty("ruleResults");
+
+            ruleResults[0].GetProperty("projectName").GetString().ShouldBe("ProjectA");
+            ruleResults[0].GetProperty("ruleName").GetString().ShouldBe("RuleA");
+            ruleResults[1].GetProperty("projectName").GetString().ShouldBe("ProjectB");
+            ruleResults[1].GetProperty("ruleName").GetString().ShouldBe("RuleA");
+            ruleResults[2].GetProperty("projectName").GetString().ShouldBe("ProjectB");
+            ruleResults[2].GetProperty("ruleName").GetString().ShouldBe("RuleB");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    #region Helpers
+
+    private static Violation CreateViolation(string ruleName, Severity severity) =>
+        new()
+        {
+            Rule = ruleName,
+            Severity = severity,
+            Adr = "docs/adr/test.md",
+            Project = "TestProject",
+            File = "Type1.cs",
+            Line = 1,
+            Message = "Test violation",
+            LlmHint = "Fix it"
+        };
+
+    private static TypeAnalysisResult CreateTypeResult(string typeName, TypeAnalysisStatus status) =>
+        new()
+        {
+            TypeName = typeName,
+            TypeFullName = $"global::{typeName}",
+            File = $"{typeName}.cs",
+            Line = 1,
+            Status = status
+        };
+
+    private static TypeAnalysisResult CreateTypeResultWithViolation(string typeName, Violation violation) =>
+        new()
+        {
+            TypeName = typeName,
+            TypeFullName = $"global::{typeName}",
+            File = $"{typeName}.cs",
+            Line = 1,
+            Status = TypeAnalysisStatus.Failed,
+            Violation = violation
+        };
+
+    private static RuleAnalysisResult CreateRuleResult(string ruleName, IReadOnlyList<TypeAnalysisResult> typeResults) =>
+        CreateRuleResultForProject(ruleName, "TestProject", typeResults);
+
+    private static RuleAnalysisResult CreateRuleResultForProject(string ruleName, string projectName, IReadOnlyList<TypeAnalysisResult> typeResults) =>
+        new()
+        {
+            RuleName = ruleName,
+            RuleDescription = $"{ruleName} description",
+            DefaultSeverity = Severity.Error,
+            AdrPath = "docs/adr/test.md",
+            ProjectName = projectName,
+            TypeResults = typeResults
+        };
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Adds **42 unit tests** covering all base infrastructure classes in `src/BuildingBlocks/Testing/Architecture/` (excluding `Rules/` directory)
- Tests cover: `TypeAnalysisStatus`, `TypeAnalysisResult`, `RuleAnalysisResult`, `ViolationManager`, and `Rule` (via concrete test implementations with in-memory Roslyn compilations)
- Classes not tested in isolation (`WorkspaceFactory`, `RuleFixture`, `RuleTestBase`, `TypeContext`) depend on MSBuild/filesystem and are covered indirectly through `Rule` tests

## Test plan
- [x] All 42 new tests pass locally
- [x] No regressions in existing 1371 tests (total: 1413)
- [x] All mutation tests pass (11 projects)
- [x] Pipeline local passed (except pre-existing Docker integration test issue)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)