### PR TITLE
feat: implement ADR DE-060 — domain interface must declare IAggregateRoot

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -363,6 +363,11 @@ através do seu aggregate root.
   de infraestrutura vazem para a camada de domínio.
 - Nomenclatura de repositório DEVE refletir intenção de
   negócio (behavior-driven), não operações CRUD.
+- Interfaces de domínio (`IUser`, `IOrder`) DEVEM herdar de
+  `IAggregateRoot` quando a entidade é um aggregate root, e
+  de `IEntity` quando é uma entidade interna. A classificação
+  DDD DEVE estar na interface, não apenas na classe concreta.
+  (Ref: ADR DE-060)
 
 **Razão**: Aggregate roots definem limites transacionais claros.
 O Handler Pattern centraliza tratamento de erros e previne

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -11,7 +11,7 @@ Estas ADRs servem como guia para **code agents** (Claude Code, GitHub Copilot, O
 | Prefixo | Categoria | Descrição | Status |
 |---------|-----------|-----------|--------|
 | **CS** | [Code Style](./code-style/README.md) | Organização de código, convenções de namespace e estrutura de diretórios | 1 ADR |
-| **DE** | [Domain Entities](./domain-entities/README.md) | Entidades de domínio, agregados e value objects | 58 ADRs |
+| **DE** | [Domain Entities](./domain-entities/README.md) | Entidades de domínio, agregados e value objects | 60 ADRs |
 | **RE** | Repositories | Persistência e acesso a dados | Em breve |
 | **AS** | Application Services | Serviços de aplicação e casos de uso | Em breve |
 | **IN** | Infrastructure | Infraestrutura, cross-cutting concerns | Em breve |

--- a/docs/adrs/domain-entities/DE-060-interface-dominio-deve-declarar-iaggregateroot.md
+++ b/docs/adrs/domain-entities/DE-060-interface-dominio-deve-declarar-iaggregateroot.md
@@ -1,0 +1,251 @@
+# DE-060: Interface de Domínio Deve Declarar IAggregateRoot
+
+## Status
+Aceita
+
+## Contexto
+
+### O Problema (Analogia)
+
+Imagine uma empresa onde o organograma diz que João é "funcionário", mas na prática ele é o CEO e toma decisões de diretoria. Quando alguém consulta o organograma para saber quem pode aprovar orçamentos, João não aparece - porque o organograma o classifica apenas como "funcionário".
+
+O problema não é que João exerça a função errada, mas que o **documento oficial** (organograma) descreve seu papel num nível errado. Quem depende do organograma toma decisões incorretas.
+
+Na programação, a interface de domínio (`IUser`, `IOrder`) é o "organograma" da entidade. Se ela declara `IEntity` quando a entidade é na verdade um Aggregate Root, todo código que depende da interface não sabe que está lidando com um Aggregate Root.
+
+### O Problema Técnico
+
+Quando a interface de domínio herda de `IEntity` mas a classe concreta implementa `IAggregateRoot`, cria-se uma **assimetria entre contrato e implementação**:
+
+```csharp
+// ❌ Interface declara nível errado
+public interface IUser : IEntity  // "Sou apenas uma entidade"
+{
+    string Username { get; }
+}
+
+// Classe concreta eleva o nível
+public sealed class User
+    : EntityBase<User>
+    , IAggregateRoot   // "Na verdade sou um Aggregate Root"
+    , IUser
+{
+}
+```
+
+Problemas concretos:
+
+1. **Repositórios não aceitam a interface**: `IRepository<T> where T : IAggregateRoot` não aceita `IUser` porque `IUser : IEntity`, não `IAggregateRoot`
+2. **Serviços de domínio forçam downcast**: Código que recebe `IUser` precisa fazer cast para `IAggregateRoot`
+3. **Incentivo ao erro incremental**: Ao adicionar um repository ou serviço de domínio, o code agent modifica a **classe** para satisfazer o constraint, em vez de corrigir a **interface**
+4. **Contrato mentiroso**: Consumidores de `IUser` não sabem que estão operando sobre um Aggregate Root
+
+## Como Normalmente É Feito
+
+### Abordagem Tradicional
+
+A maioria dos projetos define interfaces de domínio sem considerar a hierarquia DDD:
+
+```csharp
+// Interface genérica - nível de abstração indefinido
+public interface IUser
+{
+    string Username { get; }
+    string Email { get; }
+}
+
+// Classe decide sozinha o que ela é
+public class User : Entity, IAggregateRoot, IUser
+{
+    // A interface não participa da decisão
+}
+```
+
+### Por Que Não Funciona Bem
+
+1. **Decisão diferida para a classe**: A interface não expressa se a entidade é raiz de agregado ou entidade interna
+2. **Erro incremental silencioso**: Quando um novo requisito exige `IAggregateRoot` (ex: repository), o caminho de menor resistência é adicionar na classe, não na interface
+3. **Dependência invertida quebrada**: Camadas superiores dependem da interface, mas a informação arquitetural está apenas na classe concreta
+4. **Code agents erram sistematicamente**: LLMs priorizam compilação rápida - ao encontrar um constraint `where T : IAggregateRoot`, adicionam na classe porque é o caminho mais curto para compilar
+
+## A Decisão
+
+### Nossa Abordagem
+
+A interface de domínio DEVE herdar de `IAggregateRoot` quando a entidade é um Aggregate Root:
+
+```csharp
+// ✅ Interface declara o nível correto
+public interface IUser
+    : IAggregateRoot  // Contrato explícito: IUser é um Aggregate Root
+{
+    string Username { get; }
+    string Email { get; }
+    PasswordHash PasswordHash { get; }
+}
+
+// Classe implementa a interface (que já inclui IAggregateRoot)
+public sealed class User
+    : EntityBase<User>
+    , IUser            // IAggregateRoot já vem via IUser
+{
+    // ...
+}
+```
+
+Da mesma forma, para entidades internas de um agregado:
+
+```csharp
+// ✅ Entidade interna herda de IEntity (não IAggregateRoot)
+public interface IOrderItem : IEntity
+{
+    decimal Price { get; }
+    int Quantity { get; }
+}
+```
+
+### Regra
+
+> **A interface de domínio da entidade DEVE herdar da interface de infraestrutura correspondente ao seu papel no agregado:**
+> - Aggregate Root → `IAggregateRoot`
+> - Entidade interna do agregado → `IEntity`
+
+### Por Que Funciona Melhor
+
+1. **Contrato honesto**: A interface expressa exatamente o papel da entidade no domínio
+2. **Type safety propagado**: Código que recebe `IUser` já sabe que é `IAggregateRoot`
+3. **Repositories e serviços funcionam naturalmente**:
+
+```csharp
+// ✅ Funciona porque IUser : IAggregateRoot
+public interface IUserRepository : IRepository<IUser>
+{
+    Task<IUser?> FindByEmail(Email email);
+}
+```
+
+4. **Previne erro incremental**: Não há necessidade de modificar a classe quando um constraint exige `IAggregateRoot` - a interface já satisfaz
+
+## Consequências
+
+### Benefícios
+
+- **Decisão arquitetural na interface**: O papel da entidade fica no contrato, visível para todos os consumidores
+- **Eliminação de assimetria**: Interface e classe concordam sobre o nível de abstração
+- **Prevenção de erro em code agents**: LLMs não precisam "consertar" a classe porque a interface já tem a informação correta
+- **Dependency Inversion correto**: Camadas superiores dependem da interface e recebem toda a informação de tipo necessária
+
+### Trade-offs (Com Perspectiva)
+
+- **Decisão antecipada**: É preciso decidir se a entidade é Aggregate Root no momento de criar a interface. Na prática, essa decisão já é obrigatória em DDD ao modelar agregados - a ADR apenas exige que ela seja **registrada na interface** ao invés de apenas na classe.
+
+## Fundamentação Teórica
+
+### O Que o DDD Diz
+
+Eric Evans em "Domain-Driven Design" (2003):
+
+> "The root is the only member of the AGGREGATE that outside objects are allowed to hold references to."
+>
+> *A raiz é o único membro do AGGREGATE ao qual objetos externos podem manter referências.*
+
+Se objetos externos referenciam a entidade via interface, e a interface não declara que é um Aggregate Root, perde-se essa distinção fundamental. A interface é a **referência pública** da entidade - ela deve carregar a classificação correta.
+
+### O Que o Clean Architecture Diz
+
+Robert C. Martin em "Clean Architecture" (2017) enfatiza o **Dependency Inversion Principle**:
+
+> "Depend on abstractions, not on concretions."
+>
+> *Dependa de abstrações, não de implementações concretas.*
+
+Se a abstração (`IUser`) é mais pobre que a implementação (`User : IAggregateRoot`), as camadas superiores perdem informação ao depender da abstração. A interface deve ser **tão expressiva quanto necessário** para que os consumidores não precisem conhecer a classe concreta.
+
+### Padrões de Design Relacionados
+
+**Interface Segregation Principle (ISP)** - Interfaces devem ser específicas para seus consumidores. Repositories e domain services são consumidores que **precisam** saber que estão lidando com Aggregate Roots. Se a interface omite essa informação, estamos violando ISP ao forçar esses consumidores a lidar com um tipo genérico demais.
+
+**Liskov Substitution Principle (LSP)** - Se `User` implementa `IAggregateRoot` mas `IUser` não herda de `IAggregateRoot`, então `IUser` e `User` têm contratos diferentes. Código que aceita `IAggregateRoot` não pode aceitar `IUser`, quebrando a substituibilidade.
+
+## Antipadrões Documentados
+
+### Interface Herda de IEntity, Classe Implementa IAggregateRoot
+
+```csharp
+// ❌ ANTIPADRÃO: Assimetria interface/classe
+public interface IUser : IEntity { }
+
+public sealed class User
+    : EntityBase<User>
+    , IAggregateRoot   // Elevação na classe
+    , IUser
+{ }
+
+// Consequência: IUserRepository não compila
+public interface IUserRepository : IRepository<IUser> { }
+//                                              ^^^^
+// Erro: IUser não satisfaz constraint 'IAggregateRoot'
+```
+
+### Interface Sem Herança de Tipo Base
+
+```csharp
+// ❌ ANTIPADRÃO: Interface "solta" sem classificação
+public interface IUser
+{
+    string Username { get; }
+}
+
+// Problema: nenhuma informação sobre o papel da entidade
+// Code agent pode fazer qualquer coisa com IUser
+```
+
+### Classe Implementa IAggregateRoot Diretamente para "Resolver" Compilação
+
+```csharp
+// ❌ ANTIPADRÃO: Solução de menor resistência
+// Code agent encontra: IRepository<T> where T : IAggregateRoot
+// Code agent adiciona IAggregateRoot na classe em vez de corrigir a interface
+
+// Antes (interface correta mas incompleta):
+public interface IUser : IEntity { }
+
+// Depois (code agent "conserta" na classe):
+public sealed class User : EntityBase<User>, IAggregateRoot, IUser { }
+//                                           ^^^^^^^^^^^^^^
+// O fix correto seria: public interface IUser : IAggregateRoot { }
+```
+
+## Aprenda Mais
+
+### Perguntas Para Fazer à LLM
+
+- "Qual a diferença entre declarar IAggregateRoot na interface vs na classe concreta?"
+- "Como o Dependency Inversion Principle se aplica a interfaces de domínio em DDD?"
+- "Por que code agents tendem a modificar classes concretas em vez de interfaces?"
+- "Como a hierarquia de interfaces afeta generic constraints em repositórios?"
+
+### Leitura Recomendada
+
+- [Domain-Driven Design - Aggregates](https://martinfowler.com/bliki/DDD_Aggregate.html)
+- [Effective Aggregate Design](https://www.dddcommunity.org/library/vernon_2011/)
+- [Interface Segregation Principle](https://en.wikipedia.org/wiki/Interface_segregation_principle)
+
+## Decisões Relacionadas
+
+- [DE-005](./DE-005-aggregateroot-deve-implementar-iaggregateroot.md) - AggregateRoot Deve Implementar IAggregateRoot (complementar: DE-005 trata da classe, DE-060 trata da interface)
+- [DE-001](./DE-001-entidades-devem-ser-sealed.md) - Entidades Devem Ser Sealed
+- [DE-027](./DE-027-entidades-nao-tem-dependencias-externas.md) - Entidades Não Têm Dependências Externas
+
+## Building Blocks Correlacionados
+
+| Building Block | Relacao com a ADR |
+|----------------|-------------------|
+| [IAggregateRoot](../../building-blocks/domain-entities/iaggregateroot.md) | Interface marker que deve ser herdada pela interface de dominio, nao apenas implementada pela classe |
+| [IEntity](../../building-blocks/domain-entities/ientity.md) | Interface base para entidades internas do agregado (nao Aggregate Roots) |
+
+## Referências no Código
+
+- [IAggregateRoot.cs](../../../src/BuildingBlocks/Domain.Entities/Interfaces/IAggregateRoot.cs) - Definicao da interface
+- [IUser.cs](../../../samples/ShopDemo/Auth/Domain.Entities/Users/Interfaces/IUser.cs) - Exemplo correto: interface herdando IAggregateRoot
+- [User.cs](../../../samples/ShopDemo/Auth/Domain.Entities/Users/User.cs) - Classe que implementa IUser (IAggregateRoot propagado via interface)

--- a/docs/adrs/domain-entities/README.md
+++ b/docs/adrs/domain-entities/README.md
@@ -133,6 +133,12 @@ Decisões arquiteturais relacionadas a **entidades de domínio**, agregados e va
 |-----|--------|--------|
 | [DE-059](./DE-059-metadata-deve-ser-classe-aninhada.md) | Metadados Devem Ser Classe Aninhada da Entidade | Aceita |
 
+### Interfaces de Domínio
+
+| ADR | Título | Status |
+|-----|--------|--------|
+| [DE-060](./DE-060-interface-dominio-deve-declarar-iaggregateroot.md) | Interface de Domínio Deve Declarar IAggregateRoot | Aceita |
+
 ---
 
 ## Fonte

--- a/src/BuildingBlocks/Testing/Architecture/Rules/DomainEntitiesRules/DE060_DomainInterfaceMustDeclareAggregateRootRule.cs
+++ b/src/BuildingBlocks/Testing/Architecture/Rules/DomainEntitiesRules/DE060_DomainInterfaceMustDeclareAggregateRootRule.cs
@@ -1,0 +1,135 @@
+using Microsoft.CodeAnalysis;
+
+namespace Bedrock.BuildingBlocks.Testing.Architecture.Rules.DomainEntitiesRules;
+
+/// <summary>
+/// Regra DE-060: Interfaces de domínio de entidades que são Aggregate Roots
+/// devem herdar de <c>IAggregateRoot</c>, não apenas de <c>IEntity</c>.
+/// <para>
+/// A classificação DDD (Aggregate Root vs entidade interna) DEVE estar na
+/// interface de domínio, não apenas na classe concreta. Isso previne assimetria
+/// entre contrato e implementação e garante que repositórios e serviços de
+/// domínio funcionem naturalmente com a interface.
+/// </para>
+/// </summary>
+public sealed class DE060_DomainInterfaceMustDeclareAggregateRootRule : DomainEntityRuleBase
+{
+    // Properties
+    public override string Name => "DE060_DomainInterfaceMustDeclareAggregateRoot";
+    public override string Description =>
+        "Interface de domínio de Aggregate Root deve herdar IAggregateRoot (DE-060)";
+    public override Severity DefaultSeverity => Severity.Error;
+    public override string AdrPath =>
+        "docs/adrs/domain-entities/DE-060-interface-dominio-deve-declarar-iaggregateroot.md";
+
+    /// <summary>
+    /// Nome da interface marker de Aggregate Root.
+    /// </summary>
+    private const string AggregateRootInterfaceName = "IAggregateRoot";
+
+    /// <summary>
+    /// Nome da interface base de entidade.
+    /// </summary>
+    private const string EntityInterfaceName = "IEntity";
+
+    /// <summary>
+    /// Nomes de interfaces de infraestrutura que não são consideradas
+    /// "interfaces de domínio" para efeitos desta regra.
+    /// </summary>
+    private static readonly HashSet<string> InfrastructureInterfaceNames =
+    [
+        "IEntity",
+        "IAggregateRoot"
+    ];
+
+    protected override Violation? AnalyzeEntityType(TypeContext context)
+    {
+        var type = context.Type;
+
+        // Regra aplica-se apenas a Aggregate Roots
+        if (!ImplementsInterface(type, AggregateRootInterfaceName))
+            return null;
+
+        // Coletar interfaces de domínio implementadas pela classe
+        var violatingInterface = FindViolatingDomainInterface(type);
+
+        if (violatingInterface is null)
+            return null;
+
+        return new Violation
+        {
+            Rule = Name,
+            Severity = DefaultSeverity,
+            Adr = AdrPath,
+            Project = context.ProjectName,
+            File = context.RelativeFilePath,
+            Line = context.LineNumber,
+            Message = $"Interface de domínio '{violatingInterface.Name}' implementada pelo " +
+                      $"Aggregate Root '{type.Name}' herda de IEntity mas não de IAggregateRoot. " +
+                      $"A interface de domínio deve declarar IAggregateRoot",
+            LlmHint = $"Alterar a declaração de '{violatingInterface.Name}' para herdar de " +
+                      $"IAggregateRoot em vez de IEntity: " +
+                      $"'public interface {violatingInterface.Name} : IAggregateRoot'"
+        };
+    }
+
+    /// <summary>
+    /// Procura uma interface de domínio que herda de IEntity mas não de IAggregateRoot.
+    /// Retorna a primeira interface violadora encontrada, ou null se todas estão corretas.
+    /// </summary>
+    private static INamedTypeSymbol? FindViolatingDomainInterface(INamedTypeSymbol type)
+    {
+        foreach (var iface in type.Interfaces)
+        {
+            // Ignorar interfaces de infraestrutura
+            if (IsInfrastructureInterface(iface))
+                continue;
+
+            // Verificar se é uma interface de domínio (herda de IEntity)
+            if (!InheritsFromInterface(iface, EntityInterfaceName))
+                continue;
+
+            // É uma interface de domínio. Verificar se herda de IAggregateRoot.
+            if (!InheritsFromInterface(iface, AggregateRootInterfaceName))
+                return iface;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Verifica se a interface é uma das interfaces de infraestrutura do framework.
+    /// </summary>
+    private static bool IsInfrastructureInterface(INamedTypeSymbol iface)
+    {
+        return InfrastructureInterfaceNames.Contains(iface.Name);
+    }
+
+    /// <summary>
+    /// Verifica se o tipo implementa uma interface específica (direta ou indiretamente).
+    /// </summary>
+    private static bool ImplementsInterface(INamedTypeSymbol type, string interfaceName)
+    {
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (iface.Name == interfaceName)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Verifica se uma interface herda de outra interface específica (direta ou indiretamente).
+    /// </summary>
+    private static bool InheritsFromInterface(INamedTypeSymbol iface, string targetInterfaceName)
+    {
+        foreach (var inherited in iface.AllInterfaces)
+        {
+            if (inherited.Name == targetInterfaceName)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/ArchitectureTests/Templates/Domain.Entities/DomainEntitiesRuleTests.cs
+++ b/tests/ArchitectureTests/Templates/Domain.Entities/DomainEntitiesRuleTests.cs
@@ -393,4 +393,14 @@ public sealed class DomainEntitiesRuleTests : RuleTestBase<DomainEntitiesArchFix
     }
 
     #endregion
+
+    #region DE060
+
+    [Fact]
+    public void DE060_Interface_de_dominio_de_aggregate_root_deve_herdar_IAggregateRoot()
+    {
+        AssertNoViolations(new DE060_DomainInterfaceMustDeclareAggregateRootRule());
+    }
+
+    #endregion
 }

--- a/tests/UnitTests/BuildingBlocks/Testing.Architecture/Rules/DomainEntitiesRules/DE060_DomainInterfaceMustDeclareAggregateRootRuleTests.cs
+++ b/tests/UnitTests/BuildingBlocks/Testing.Architecture/Rules/DomainEntitiesRules/DE060_DomainInterfaceMustDeclareAggregateRootRuleTests.cs
@@ -1,0 +1,344 @@
+using Bedrock.BuildingBlocks.Testing;
+using Bedrock.BuildingBlocks.Testing.Architecture;
+using Bedrock.BuildingBlocks.Testing.Architecture.Rules.DomainEntitiesRules;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bedrock.UnitTests.BuildingBlocks.Testing.Architecture.Rules.DomainEntitiesRules;
+
+public class DE060_DomainInterfaceMustDeclareAggregateRootRuleTests : TestBase
+{
+    public DE060_DomainInterfaceMustDeclareAggregateRootRuleTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void InterfaceWithIAggregateRoot_ShouldPass()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root with domain interface inheriting IAggregateRoot");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IUser : IAggregateRoot
+            {
+                string Username { get; }
+            }
+            public sealed class User : EntityBase<User>, IUser
+            {
+                public string Username { get; private set; } = string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing aggregate root with correct domain interface");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying aggregate root with IAggregateRoot interface passes");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "User");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    [Fact]
+    public void InterfaceWithIEntity_OnAggregateRoot_ShouldFail()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root with domain interface inheriting only IEntity");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IUser : IEntity
+            {
+                string Username { get; }
+            }
+            public sealed class User : EntityBase<User>, IAggregateRoot, IUser
+            {
+                public string Username { get; private set; } = string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing aggregate root with IEntity-only domain interface");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying aggregate root with IEntity-only interface fails");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "User");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Failed);
+        typeResult.Violation.ShouldNotBeNull();
+        typeResult.Violation!.Rule.ShouldBe("DE060_DomainInterfaceMustDeclareAggregateRoot");
+        typeResult.Violation.Message.ShouldContain("IUser");
+        typeResult.Violation.Message.ShouldContain("IAggregateRoot");
+    }
+
+    [Fact]
+    public void InterfaceWithoutEntityHierarchy_ShouldBeIgnored()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root with non-domain interface");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IFormattable
+            {
+                string Format();
+            }
+            public sealed class Order : EntityBase<Order>, IAggregateRoot, IFormattable
+            {
+                public string Format() => string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing aggregate root with non-domain interface");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying non-domain interface is ignored");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "Order");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    [Fact]
+    public void EntityNotAggregateRoot_ShouldBeIgnored()
+    {
+        // Arrange
+        LogArrange("Creating entity (not aggregate root) with IEntity interface");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IOrderItem : IEntity
+            {
+                decimal Price { get; }
+            }
+            public sealed class OrderItem : EntityBase<OrderItem>, IOrderItem
+            {
+                public decimal Price { get; private set; }
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing entity that is not an aggregate root");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying non-aggregate-root entity is ignored");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "OrderItem");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    [Fact]
+    public void ClassWithoutDomainInterface_ShouldBeIgnored()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root without any domain interface");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public sealed class SimpleAggregateRoot : EntityBase<SimpleAggregateRoot>, IAggregateRoot
+            {
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing aggregate root without domain interface");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying aggregate root without domain interface passes");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "SimpleAggregateRoot");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    [Fact]
+    public void InterfaceInheritingIAggregateRootIndirectly_ShouldPass()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root with interface inheriting IAggregateRoot indirectly");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IBaseUser : IAggregateRoot
+            {
+                string Username { get; }
+            }
+            public interface IUser : IBaseUser
+            {
+                string Email { get; }
+            }
+            public sealed class User : EntityBase<User>, IUser
+            {
+                public string Username { get; private set; } = string.Empty;
+                public string Email { get; private set; } = string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing aggregate root with indirect IAggregateRoot inheritance");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying indirect IAggregateRoot inheritance passes");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "User");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    [Fact]
+    public void ViolationMetadata_ShouldBeCorrect()
+    {
+        // Arrange
+        LogArrange("Creating aggregate root to verify violation metadata");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface IInvoice : IEntity
+            {
+                string Number { get; }
+            }
+            public sealed class Invoice : EntityBase<Invoice>, IAggregateRoot, IInvoice
+            {
+                public string Number { get; private set; } = string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing violation metadata");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying violation metadata fields");
+        var typeResult = results[0].TypeResults.First(t => t.TypeName == "Invoice");
+        var violation = typeResult.Violation!;
+
+        violation.Rule.ShouldBe("DE060_DomainInterfaceMustDeclareAggregateRoot");
+        violation.Severity.ShouldBe(Severity.Error);
+        violation.Adr.ShouldBe("docs/adrs/domain-entities/DE-060-interface-dominio-deve-declarar-iaggregateroot.md");
+        violation.LlmHint.ShouldContain("IAggregateRoot");
+        violation.LlmHint.ShouldContain("IInvoice");
+        violation.Message.ShouldContain("IInvoice");
+        violation.Message.ShouldContain("Invoice");
+    }
+
+    [Fact]
+    public void RuleProperties_ShouldBeCorrect()
+    {
+        // Arrange
+        LogArrange("Creating rule to verify properties");
+
+        // Act
+        LogAct("Reading rule properties");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+
+        // Assert
+        LogAssert("Verifying rule properties");
+        rule.Name.ShouldBe("DE060_DomainInterfaceMustDeclareAggregateRoot");
+        rule.Description.ShouldContain("IAggregateRoot");
+        rule.DefaultSeverity.ShouldBe(Severity.Error);
+        rule.AdrPath.ShouldBe("docs/adrs/domain-entities/DE-060-interface-dominio-deve-declarar-iaggregateroot.md");
+    }
+
+    [Fact]
+    public void AbstractClass_ShouldBeIgnored()
+    {
+        // Arrange
+        LogArrange("Creating abstract class with IEntity interface");
+        var rule = new DE060_DomainInterfaceMustDeclareAggregateRootRule();
+        var source = """
+            #nullable enable
+            public interface IEntity { }
+            public interface IAggregateRoot : IEntity { }
+            public abstract class EntityBase<T> where T : EntityBase<T> { }
+            public interface ICustomer : IEntity
+            {
+                string Name { get; }
+            }
+            public abstract class CustomerBase : EntityBase<CustomerBase>, IAggregateRoot, ICustomer
+            {
+                public string Name { get; } = string.Empty;
+            }
+            """;
+        var compilations = CreateCompilations(source);
+
+        // Act
+        LogAct("Analyzing abstract class");
+        var results = rule.Analyze(compilations, Path.GetTempPath());
+
+        // Assert
+        LogAssert("Verifying abstract class is ignored by DomainEntityRuleBase");
+        results.Count.ShouldBe(1);
+        var typeResult = results[0].TypeResults.FirstOrDefault(t => t.TypeName == "CustomerBase");
+        typeResult.ShouldNotBeNull();
+        typeResult.Status.ShouldBe(TypeAnalysisStatus.Passed);
+    }
+
+    #region Helpers
+
+    private static Dictionary<string, Compilation> CreateCompilations(string source)
+    {
+        return new Dictionary<string, Compilation>
+        {
+            ["TestProject"] = CreateSingleCompilation(source, "TestProject")
+        };
+    }
+
+    private static Compilation CreateSingleCompilation(string source, string assemblyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "TestFile.cs");
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+        };
+
+        return CSharpCompilation.Create(
+            assemblyName,
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Implements ADR DE-060: domain interfaces of Aggregate Roots must inherit `IAggregateRoot`, not just `IEntity`
- Adds Roslyn architecture rule `DE060_DomainInterfaceMustDeclareAggregateRootRule` to detect asymmetry between interface and class
- Prevents the antipattern where `IUser : IEntity` but `User : IAggregateRoot` — the DDD classification must live in the interface
- Updates constitution BB-V with the new constraint

## What's included

| Artifact | Description |
|----------|-------------|
| ADR DE-060 | Full ADR with analogies, antipatterns, fundamentação teórica (DDD, SOLID, Clean Architecture) |
| Roslyn Rule | Analyzes concrete classes: if class is AR + implements domain interface → interface must inherit IAggregateRoot |
| Unit Tests | 9 tests covering pass, fail, ignore, indirect inheritance, metadata, and rule properties |
| Architecture Test | Registered in DomainEntitiesRuleTests for enforcement against templates + ShopDemo |
| Constitution | BB-V updated with the interface-level IAggregateRoot requirement |

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` (DE060 unit tests) — 9/9 passed
- [x] Architecture tests — all 60 DE rules pass
- [x] Full pipeline (build + arch + tests + mutation) — all green, 100% mutation score

🤖 Generated with [Claude Code](https://claude.com/claude-code)