### PR TITLE
fix: remove PowerShell from pipeline scripts, rewrite in pure bash+awk

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -23,8 +23,4 @@ rm -rf TestResults/
 rm -rf StrykerOutput/
 rm -rf coverage/
 rm -rf mutation-reports/
-
-# Remove temporary PowerShell scripts (if any)
-rm -f scripts/replace-namespace*.ps1
-
 echo "Done: Cleaned all artifacts and temporary files"


### PR DESCRIPTION
## Summary
- Remove all PowerShell usage from `scripts/summarize.sh` and `scripts/sonar-check.sh`, replacing with pure bash (awk/sed/grep) for cross-platform compatibility
- PowerShell commands were silently failing on MINGW64 due to `\$` escaping issues, with `2>/dev/null` hiding all errors — mutation and coverage extraction never actually executed locally
- `scripts/clean.sh` updated to remove obsolete PowerShell cleanup references

## Changes
- **`scripts/summarize.sh`**: Mutation JSON parsing via awk state machine; cobertura XML parsing via awk with `FS='"'`; glob-to-regex exclusion pattern matching in bash
- **`scripts/sonar-check.sh`**: SonarCloud JSON processing via `grep -o`/`cut`/`sed` with process substitution to preserve loop state
- **`scripts/clean.sh`**: Removed `rm -f scripts/replace-namespace*.ps1` cleanup

## Test plan
- [x] `bash -n` syntax check passes on all 3 scripts
- [x] Full `./scripts/pipeline.sh` runs successfully (2590 tests, 0 mutants, 0 architecture violations, 0 SonarCloud issues)
- [x] Coverage extraction now works correctly (previously showed 0 due to silent PowerShell failures)
- [ ] CI pipeline passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)